### PR TITLE
Refine data processor utilities and recommendation confidence

### DIFF
--- a/services/data_processor.py
+++ b/services/data_processor.py
@@ -7,9 +7,18 @@ from logger import logger
 from services.sportmonks_client import sportmonks_client
 # Исправлено: Импорт правильного кэша
 from database.cache_postgres import cache
-import math
+# (cleanup) удалён неиспользуемый глобальный импорт math
 import numpy as np
-import pandas as pd # Перемещен импорт в основную секцию
+import pandas as pd
+
+# (cleanup) удалён мусорный `return None` вне функций
+# (cleanup) удалён артефакт `main`
+# (cleanup) удалены повторные импорты numpy/pandas внизу файла (если присутствовали)
+# (cleanup) Удалены глобальные дубликаты утилит:
+# parse_dt_safe, compute_rest_days, style_mismatch,
+# ewma, add_missing_ratio, load_climate_norm, haversine_km.
+# Оставлены только методы внутри класса DataProcessor.
+
 class DataProcessor:
     """Класс для обработки данных матчей."""
     def __init__(self):
@@ -17,6 +26,21 @@ class DataProcessor:
         self.client = sportmonks_client
         # Исправлено: Используем правильный экземпляр кэша
         self.cache = cache
+
+    def parse_dt_safe(self, date_str: str):
+        """Парсинг даты с обработкой ошибок (без print, через логер)."""
+        if not date_str:
+            return None
+        try:
+            # быстрый ISO-путь
+            if "T" in date_str or "Z" in date_str:
+                ds = date_str.replace("Z", "").replace("T", " ")[:19]
+                return datetime.fromisoformat(ds)
+            # fallback на формат "%Y-%m-%d %H:%M:%S"
+            return datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
+        except Exception as e:
+            logger.warning("parse_dt_safe: failed to parse %r: %s", date_str, e)
+            return None
     def compute_rest_days(self, prev_match_dt: datetime, next_match_dt: datetime) -> int:
         """
         Вычисление количества дней отдыха между матчами.
@@ -91,6 +115,7 @@ class DataProcessor:
         Returns:
             float: Расстояние в километрах.
         """
+        import math
         try:
             # Проверка на None
             if lat1 is None or lon1 is None or lat2 is None or lon2 is None:
@@ -809,6 +834,13 @@ class DataProcessor:
             logger.error(f"Ошибка при расчете признаков стрик: {e}")
             # Возвращаем значения по умолчанию в случае ошибки
             return {"win_streak": 0, "dry_spell": 0, "burst": 0}
+    def add_missing_ratio(self, df) -> float:
+        total_entries = getattr(df, "size", 0)
+        if total_entries == 0:
+            return 0.0
+        missing_entries = df.isnull().sum().sum()
+        return float(missing_entries) / int(total_entries)
+
     def add_missing_mask(self, features: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, int]]:
         """
         Добавление маски пропущенных значений к признакам.


### PR DESCRIPTION
## Summary
- improve `DataProcessor.parse_dt_safe` to log failures and parse ISO timestamps
- guard `DataProcessor.add_missing_ratio` against missing size attribute and safe division
- remove redundant top-level utility definitions in `services/data_processor.py`
- drop unused global `math` import and localize it inside `haversine_km`
- compute recommendation confidence from outcome margin with penalties and async DB logging
- prune unused imports and legacy typing in `RecommendationEngine`
- centralize confidence helpers inside `RecommendationEngine` with support for 2- and 3-outcome probabilities
- use `predict` for isotonic calibration and guard against zero-sum normalization
- add weighted `EnsembleCombiner` that tolerates missing outcomes
- expose `compute_confidence_from_margin` and `penalize_confidence` as instance methods and route all calls through them

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a451db8f38832eba77a97d1b68159f