### PR TITLE
feat(app): add data_processor facade package

### DIFF
--- a/app/data_processor/__init__.py
+++ b/app/data_processor/__init__.py
@@ -1,0 +1,12 @@
+/**
+ * @file: __init__.py
+ * @description: Facade for the data_processor package with backward compatibility.
+ * @dependencies: data_processor legacy module
+ * @created: 2025-09-10
+ */
+# Фасад: импортируем из старого модуля для обратной совместимости
+import data_processor as legacy
+from .validators import validate_required_columns
+from .feature_engineering import build_features
+from .transformers import make_transformers
+from .io import load_data, save_data

--- a/app/data_processor/feature_engineering.py
+++ b/app/data_processor/feature_engineering.py
@@ -1,0 +1,20 @@
+/**
+ * @file: feature_engineering.py
+ * @description: Feature engineering helpers.
+ * @dependencies: pandas, data_processor.build_features
+ * @created: 2025-09-10
+ */
+from __future__ import annotations
+import pandas as pd
+try:
+    from data_processor import build_features as _impl  # type: ignore
+except Exception:
+    _impl = None
+
+
+def build_features(df: pd.DataFrame) -> pd.DataFrame:
+    if _impl:
+        return _impl(df)
+    # минимальная заглушка
+    df = df.copy()
+    return df

--- a/app/data_processor/io.py
+++ b/app/data_processor/io.py
@@ -1,0 +1,25 @@
+/**
+ * @file: io.py
+ * @description: Data input/output helpers.
+ * @dependencies: pandas, data_processor.load_data, data_processor.save_data
+ * @created: 2025-09-10
+ */
+from __future__ import annotations
+import pandas as pd
+try:
+    from data_processor import load_data as _load, save_data as _save  # type: ignore
+except Exception:
+    _load = _save = None
+
+
+def load_data(path: str) -> pd.DataFrame:
+    if _load:
+        return _load(path)
+    return pd.read_csv(path)
+
+
+def save_data(df: pd.DataFrame, path: str) -> None:
+    if _save:
+        _save(df, path)
+        return
+    df.to_csv(path, index=False)

--- a/app/data_processor/transformers.py
+++ b/app/data_processor/transformers.py
@@ -1,0 +1,26 @@
+/**
+ * @file: transformers.py
+ * @description: Transformer builders for preprocessing pipelines.
+ * @dependencies: data_processor.make_transformers
+ * @created: 2025-09-10
+ */
+from __future__ import annotations
+from typing import Any
+try:
+    from data_processor import make_transformers as _impl  # type: ignore
+except Exception:
+    _impl = None
+
+
+def make_transformers(*args, **kwargs) -> Any:
+    if _impl:
+        return _impl(*args, **kwargs)
+
+    class _Identity:
+        def fit(self, X, y=None):
+            return self
+
+        def transform(self, X):
+            return X
+
+    return _Identity()

--- a/app/data_processor/validators.py
+++ b/app/data_processor/validators.py
@@ -1,0 +1,21 @@
+/**
+ * @file: validators.py
+ * @description: Column validation utilities for data processing.
+ * @dependencies: pandas, data_processor.validate_required_columns
+ * @created: 2025-09-10
+ */
+from __future__ import annotations
+import pandas as pd
+try:
+    from data_processor import validate_required_columns as _impl  # type: ignore
+except Exception:
+    _impl = None
+
+
+def validate_required_columns(df: pd.DataFrame, required: list[str]) -> pd.DataFrame:
+    if _impl:
+        return _impl(df, required)
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {missing}")
+    return df

--- a/docs/Project.md
+++ b/docs/Project.md
@@ -27,6 +27,13 @@ telegram-bot/
 ├─ config.py                 | настройки, MODEL_VERSION, env
 ├─ logger.py                 | логирование (Loguru JSON + Sentry)
 ├─ observability.py          | инициализация Sentry и Prometheus
+├─ app/
+│  └─ data_processor/           | фасад старого data_processor.py
+│     ├─ __init__.py
+│     ├─ validators.py
+│     ├─ feature_engineering.py
+│     ├─ transformers.py
+│     └─ io.py
 ├─ metrics/                  | ECE/LogLoss метрики
 │  └─ metrics.py
 ├─ database/                 | PostgreSQL+Redis, миграции

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,11 @@
+## [2025-09-10] - Декомпозиция data_processor в пакет
+### Добавлено
+- Пакет `app/data_processor` с фасадом и модулями validators, feature_engineering, transformers и io.
+### Изменено
+- Обновлена архитектура в Project.md.
+### Исправлено
+- —
+
 ## [2025-09-10] - Заглушки ML-пайплайна
 ### Добавлено
 - Заглушечные модули prediction_pipeline, train_base_glm, train_modifiers и retrain_scheduler.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -113,3 +113,12 @@
   - [x] Добавлены проверки обязательных колонок в data_processor.py
   - [x] Обновлён qa.md с уточнёнными вопросами по данным
 - **Зависимости**: Project.md (раздел 5), services/data_processor.py
+ 
+## Задача: Декомпозиция data_processor в пакет
+- **Статус**: Завершена
+- **Описание**: Создать пакет app/data_processor с фасадом и модулями validators, feature_engineering, transformers и io.
+- **Шаги выполнения**:
+  - [x] Создан пакет и фасад __init__.py
+  - [x] Вынесены модули validators, feature_engineering, transformers и io
+  - [x] Обновлена документация
+- **Зависимости**: app/data_processor


### PR DESCRIPTION
## Summary
- scaffold app.data_processor package with facade modules delegating to legacy implementation
- document new package in Project architecture
- record package addition in changelog and tasktracker

## Testing
- `pre-commit run --files app/data_processor/__init__.py app/data_processor/validators.py app/data_processor/feature_engineering.py app/data_processor/transformers.py app/data_processor/io.py docs/Project.md docs/changelog.md docs/tasktracker.md` *(failed: fatal unable to access https://github.com/psf/black/ 403)*
- `pytest -q` *(failed: ValueError: API token for SportMonks is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c10f65b16c832e93f3b2b82c8cc04f