### PR TITLE
feat(services): add prediction pipeline and retrain scheduler skeletons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,13 @@ PROMETHEUS_ENDPOINT=/metrics
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_REQUESTS=60
 RATE_LIMIT_PER_SECONDS=60
+
+# ML / Retrain
+MODEL_REGISTRY_PATH=artifacts/
+RETRAIN_CRON=0 3 * * *
+# пример интеграции: см. app/ml/retrain_scheduler.py
+# для локального режима оставить как есть
+
+# Services/Workers
+# prediction pipeline и планировщик будут читать эти значения при инициализации
+# (см. services/prediction_pipeline.py, workers/retrain_scheduler.py)

--- a/README.md
+++ b/README.md
@@ -18,3 +18,24 @@ make check
 ```
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) and `docs/Project.md` for more details.
+
+## Services & Workers (скелеты)
+
+Добавлены минимальные заготовки для боевого включения без падений в ограниченных окружениях:
+
+- `services/prediction_pipeline.py` — продовый фасад предсказаний:
+  - интерфейсы `Preprocessor`, `ModelRegistry`;
+  - заглушечная модель, если реестр не доступен;
+  - устойчив к отсутствию `numpy/pandas` (вернёт список списков).
+
+- `workers/retrain_scheduler.py` — регистрация периодического переобучения:
+  - `schedule_retrain(register, cron_expr=None, task=None)`;
+  - читает `RETRAIN_CRON` из окружения (по умолчанию `0 3 * * *`);
+  - ленивая подгрузка тренера для избежания тяжёлых импортов.
+
+Быстрая проверка:
+```bash
+pytest -q -k test_services_workers_minimal
+```
+
+> Тесты помечены `@pytest.mark.needs_np`: при недоступном численном стеке будут SKIP.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,12 @@
+## [2025-09-12] - Скелеты сервисов и планировщика
+### Добавлено
+- Минимальные скелеты `services/prediction_pipeline.py` и `workers/retrain_scheduler.py`.
+- Тесты `test_services_workers_minimal.py`.
+### Изменено
+- README.md: добавлен раздел Services & Workers.
+- .env.example: добавлен блок Services/Workers.
+### Исправлено
+- —
 ## [2025-09-12] - Синхронизация pandas и метрики
 ### Добавлено
 - Реализована функция `record_prediction` с обновлением скользящих метрик.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,11 @@
+## Задача: Скелеты сервисов и планировщика
+- **Статус**: Завершена
+- **Описание**: Добавить минимальные скелеты PredictionPipeline и Retrain Scheduler, тесты и обновить документацию.
+- **Шаги выполнения**:
+  - [x] Реализовать `services/prediction_pipeline.py`
+  - [x] Реализовать `workers/retrain_scheduler.py`
+  - [x] Добавить тесты и обновить README/.env
+- **Зависимости**: services/prediction_pipeline.py, workers/retrain_scheduler.py, tests/test_services_workers_minimal.py, README.md, .env.example
 ## Задача: Синхронизация pandas
 - **Статус**: Завершена
 - **Описание**: Закрепить версию `pandas==2.2.2` в зависимостях проекта.

--- a/services/prediction_pipeline.py
+++ b/services/prediction_pipeline.py
@@ -1,0 +1,58 @@
+"""
+@file: prediction_pipeline.py
+@description: Minimal prediction pipeline skeleton for production wiring.
+@dependencies: pandas (optional), numpy (optional), Preprocessor, ModelRegistry
+@created: 2025-09-12
+"""
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+try:  # optional import for constrained environments
+    import pandas as pd  # type: ignore
+except Exception:  # pragma: no cover
+    pd = Any  # type: ignore
+
+
+class Preprocessor(Protocol):
+    def transform(self, df: "pd.DataFrame") -> "pd.DataFrame": ...
+
+
+class ModelRegistry(Protocol):
+    def load(self, name: str): ...
+
+
+class _DummyModel:
+    def predict_proba(self, X):
+        try:
+            import numpy as np
+
+            return np.full((len(X), 2), 0.5, dtype=float)
+        except Exception:  # no numpy available
+            return [[0.5, 0.5] for _ in range(len(X))]
+
+
+class PredictionPipeline:
+    """
+    Basic flow:
+      df -> preprocessor.transform -> X
+      model = registry.load("current") or _DummyModel()
+      return model.predict_proba(X) or model.predict(X)
+    """
+
+    def __init__(self, preprocessor: Preprocessor, model_registry: ModelRegistry | None = None):
+        self._pre = preprocessor
+        self._reg = model_registry
+
+    def _load_model(self):
+        if self._reg is None:
+            return _DummyModel()
+        m = self._reg.load("current")
+        return m or _DummyModel()
+
+    def predict_proba(self, df: "pd.DataFrame"):
+        X = self._pre.transform(df)
+        model = self._load_model()
+        if hasattr(model, "predict_proba"):
+            return model.predict_proba(X)
+        return model.predict(X)

--- a/tests/test_services_workers_minimal.py
+++ b/tests/test_services_workers_minimal.py
@@ -1,0 +1,55 @@
+"""
+@file: test_services_workers_minimal.py
+@description: Tests for minimal services and worker skeletons.
+@dependencies: pytest, pandas, numpy
+@created: 2025-09-12
+"""
+import pytest
+
+# Mark the file as requiring numerical stack; will SKIP if numpy/pandas unavailable
+pytestmark = pytest.mark.needs_np
+
+
+def test_services_prediction_pipeline_stub():
+    try:
+        import pandas as pd
+        import numpy as np  # noqa: F401
+    except Exception:
+        pytest.skip("numerical stack unavailable")
+
+    from services.prediction_pipeline import PredictionPipeline
+
+    class _Preproc:
+        def transform(self, df: "pd.DataFrame") -> "pd.DataFrame":
+            return df.fillna(0)
+
+    class _Registry:
+        class _M:
+            def predict_proba(self, X):
+                import numpy as np
+
+                return np.full((len(X), 2), 0.5)
+
+        def load(self, name: str):
+            return self._M()
+
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    pipe = PredictionPipeline(preprocessor=_Preproc(), model_registry=_Registry())
+    out = pipe.predict_proba(df)
+    assert getattr(out, "shape", None) == (3, 2)
+
+
+def test_workers_retrain_scheduler_register_called(monkeypatch):
+    calls = {}
+
+    def _register(cron, fn):
+        calls["cron"] = cron
+        calls["fn"] = fn
+
+    from workers.retrain_scheduler import schedule_retrain
+
+    used = schedule_retrain(_register, cron_expr="0 4 * * *")
+    assert used == "0 4 * * *"
+    assert "cron" in calls and "fn" in calls
+    # ensure callable
+    calls["fn"]()

--- a/workers/retrain_scheduler.py
+++ b/workers/retrain_scheduler.py
@@ -1,0 +1,45 @@
+"""
+@file: retrain_scheduler.py
+@description: Minimal retrain scheduler wiring with env-based cron.
+@dependencies: os, optional training task
+@created: 2025-09-12
+"""
+from __future__ import annotations
+
+import os
+from typing import Callable, Optional
+
+
+def _default_task():
+    """
+    Lazy import to avoid heavy deps at import time.
+    Replace with actual training job body later.
+    """
+    try:
+        # prefer project-local trainer if present
+        from app.ml.train_base_glm import train_base_glm  # type: ignore
+
+        train_base_glm(train_df=None, cfg=None)
+        return
+    except Exception:
+        pass
+
+    # fallback: lightweight no-op
+    return None
+
+
+def schedule_retrain(
+    register: Callable[[str, Callable[[], None]], None],
+    cron_expr: Optional[str] = None,
+    task: Optional[Callable[[], None]] = None,
+) -> str:
+    """
+    Register periodic retrain job.
+    - register: function provided by your scheduler integration
+    - cron_expr: optional cron string; if None, uses env RETRAIN_CRON or default
+    - task: optional callable; if None, uses _default_task
+    Returns the effective cron expression used (for logging/tests).
+    """
+    effective_cron = cron_expr or os.getenv("RETRAIN_CRON", "0 3 * * *")
+    register(effective_cron, task or _default_task)
+    return effective_cron


### PR DESCRIPTION
## Summary
- add minimal prediction pipeline and retrain scheduler skeletons
- document services/workers usage and env vars
- cover services/workers with minimal tests

## Testing
- `pytest -q -k test_services_workers_minimal`

------
https://chatgpt.com/codex/tasks/task_e_68c3d8c7796c832ea7e57c1e00e7538e