### PR TITLE
feat: add retrain scheduler feature flag and smoke test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,12 @@ RATE_LIMIT_PER_SECONDS=60
 
 # ML / Retrain
 MODEL_REGISTRY_PATH=artifacts/
-RETRAIN_CRON=0 3 * * *
-# пример интеграции: см. app/ml/retrain_scheduler.py
-# для локального режима оставить как есть
+# RETRAIN_CRON включает планировщик переобучения.
+# Оставьте пустым, чтобы ОТКЛЮЧИТЬ (по умолчанию).
+# Примеры:
+# RETRAIN_CRON=0 3 * * *
+# RETRAIN_CRON=*/15 * * * *
+# RETRAIN_CRON=
 
 # Services/Workers
 # prediction pipeline и планировщик будут читать эти значения при инициализации

--- a/README.md
+++ b/README.md
@@ -39,3 +39,24 @@ pytest -q -k test_services_workers_minimal
 ```
 
 > Тесты помечены `@pytest.mark.needs_np`: при недоступном численном стеке будут SKIP.
+
+## Retrain scheduler (feature-flag)
+
+Встроена «лёгкая» интеграция планировщика:
+
+- **ENV-флаг**: `RETRAIN_CRON`
+  - пусто / `off` / `disabled` / `none` / `false` → **планировщик выключен**;
+  - любое корректное выражение crontab → регистрируется задача переобучения.
+- **Адаптер**: in-memory `workers/runtime_scheduler.py` (для smoke/локалки).
+- **Эндпоинт**: `GET /__smoke__/retrain` — статус регистрации: enabled/count/crons.
+
+Быстрая проверка:
+```bash
+RETRAIN_CRON="*/15 * * * *" uvicorn app.main:app --reload &
+curl -s http://127.0.0.1:8000/__smoke__/retrain
+```
+
+Тест:
+```bash
+pytest -q -k test_retrain_registration
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,13 @@
+## [2025-09-12] - Feature-flag retrain scheduler and smoke endpoint
+### Добавлено
+- In-memory runtime scheduler adapter `workers/runtime_scheduler.py`.
+- Smoke endpoint `/__smoke__/retrain` with feature flag `RETRAIN_CRON`.
+### Изменено
+- `app/main.py`: интеграция планировщика переобучения.
+- `.env.example`, `README.md`: документация по флагу `RETRAIN_CRON`.
+### Исправлено
+- —
+
 ## [2025-09-12] - Скелеты сервисов и планировщика
 ### Добавлено
 - Минимальные скелеты `services/prediction_pipeline.py` и `workers/retrain_scheduler.py`.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: Feature-flag retrain scheduler
+- **Статус**: Завершена
+- **Описание**: Включить планировщик переобучения по фиче-флагу и добавить smoke эндпоинт.
+- **Шаги выполнения**:
+  - [x] Реализовать in-memory runtime scheduler
+  - [x] Провести wiring в app.main и добавить smoke эндпоинт
+  - [x] Обновить README и .env.example
+- **Зависимости**: workers/runtime_scheduler.py, app/main.py, README.md, .env.example, tests/smoke/test_retrain_registration.py
+
 ## Задача: Скелеты сервисов и планировщика
 - **Статус**: Завершена
 - **Описание**: Добавить минимальные скелеты PredictionPipeline и Retrain Scheduler, тесты и обновить документацию.

--- a/tests/smoke/test_retrain_registration.py
+++ b/tests/smoke/test_retrain_registration.py
@@ -1,0 +1,53 @@
+"""
+@file: tests/smoke/test_retrain_registration.py
+@description: Smoke tests for retrain scheduler registration feature flag.
+@dependencies: app.main, workers.runtime_scheduler
+@created: 2025-09-12
+"""
+
+import importlib
+import os
+import sys
+from fastapi.testclient import TestClient
+
+
+def test_retrain_registration_feature_flag(monkeypatch):
+    # make sure runtime registry is empty
+    import workers.runtime_scheduler as rs
+    rs.clear_jobs()
+
+    # enable feature flag via env
+    monkeypatch.setenv("RETRAIN_CRON", "*/15 * * * *")
+
+    # reload app.main to re-run init wiring under new env
+    if "app.main" in sys.modules:
+        importlib.reload(sys.modules["app.main"])
+    else:
+        import app.main  # noqa: F401
+
+    from app.main import app  # type: ignore
+    c = TestClient(app)
+    r = c.get("/__smoke__/retrain")
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["enabled"] is True
+    assert payload["count"] >= 1
+    assert "*/15 * * * *" in payload["crons"]
+
+
+def test_retrain_registration_disabled_by_default(monkeypatch):
+    import workers.runtime_scheduler as rs
+    rs.clear_jobs()
+    # disable via empty / explicit off
+    monkeypatch.delenv("RETRAIN_CRON", raising=False)
+
+    if "app.main" in sys.modules:
+        importlib.reload(sys.modules["app.main"])
+    else:
+        import app.main  # noqa: F401
+
+    from app.main import app  # type: ignore
+    c = TestClient(app)
+    r = c.get("/__smoke__/retrain")
+    assert r.json()["enabled"] in (False, None)
+    assert r.json()["count"] == 0

--- a/workers/runtime_scheduler.py
+++ b/workers/runtime_scheduler.py
@@ -1,0 +1,28 @@
+"""
+@file: workers/runtime_scheduler.py
+@description: Minimal in-memory runtime scheduler adapter for wiring and smoke checks.
+@dependencies: workers.retrain_scheduler
+@created: 2025-09-12
+"""
+
+from __future__ import annotations
+from typing import Callable, Any, Dict, List
+
+_SCHEDULED: List[Dict[str, Any]] = []
+
+def register(cron_expr: str, fn: Callable[[], None]) -> None:
+    """Append a job into in-memory registry (no real scheduling)."""
+    _SCHEDULED.append({"cron": cron_expr, "fn": fn})
+
+
+def list_jobs() -> List[Dict[str, Any]]:
+    """Return a shallow copy of registered jobs with callable flag only."""
+    out: List[Dict[str, Any]] = []
+    for j in _SCHEDULED:
+        out.append({"cron": j.get("cron"), "callable": callable(j.get("fn"))})
+    return out
+
+
+def clear_jobs() -> None:
+    """Clear all registered jobs (useful for tests)."""
+    _SCHEDULED.clear()


### PR DESCRIPTION
## Summary
- add in-memory runtime scheduler adapter and wire RETRAIN_CRON feature flag
- expose `/__smoke__/retrain` endpoint with tests
- document retrain scheduler configuration

## Testing
- `pre-commit run --files .env.example README.md app/main.py docs/changelog.md docs/tasktracker.md tests/smoke/test_retrain_registration.py workers/runtime_scheduler.py` *(failed: fatal: unable to access 'https://github.com/psf/black/': CONNECT tunnel failed, response 403)*
- `pytest -q -k test_retrain_registration`

------
https://chatgpt.com/codex/tasks/task_e_68c3da0db248832e8ccb113702d23c22