### PR TITLE
feat(integrations): add SportMonks stub client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ APP_NAME=ml-service
 DEBUG=false
 TELEGRAM_BOT_TOKEN=""
 SPORTMONKS_API_KEY=""
+
+# Включение заглушки SportMonks (автоматически включается если ключ пустой или dummy)
+SPORTMONKS_STUB=1
 ODDS_API_KEY=""
 DATABASE_URL=postgresql+asyncpg://user:pass@postgres:5432/sports
 REDIS_HOST=localhost

--- a/app/integrations/__init__.py
+++ b/app/integrations/__init__.py
@@ -1,0 +1,6 @@
+"""
+@file: __init__.py
+@description: Package for integrations with external services
+@dependencies: 
+@created: 2025-09-15
+"""

--- a/app/integrations/sportmonks_client.py
+++ b/app/integrations/sportmonks_client.py
@@ -1,0 +1,80 @@
+"""
+@file: sportmonks_client.py
+@description: SportMonks client with optional stub mode for testing
+@dependencies: requests (real mode)
+@created: 2025-09-15
+SportMonks client with STUB mode.
+- Если переменная окружения SPORTMONKS_STUB=1 или SPORTMONKS_API_KEY пустой/равен "dummy",
+  используется заглушка без реальных сетевых вызовов.
+- Это позволяет запускать тесты и сервис локально без реального API-ключа.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class SportMonksConfig:
+    api_key: str | None
+    stub: bool
+    base_url: str = "https://api.sportmonks.com/v3"
+
+    @classmethod
+    def from_env(cls) -> SportMonksConfig:
+        key = os.getenv("SPORTMONKS_API_KEY")
+        stub_flag = os.getenv("SPORTMONKS_STUB", "0") == "1" or not key or key.lower() == "dummy"
+        return cls(api_key=key, stub=stub_flag)
+
+
+class SportMonksClient:
+    def __init__(self, cfg: SportMonksConfig | None = None):
+        self.cfg = cfg or SportMonksConfig.from_env()
+
+    def leagues(self) -> list[dict[str, Any]]:
+        if self.cfg.stub:
+            return [
+                {"id": 1, "name": "Stub Premier League", "country": "GB"},
+                {"id": 2, "name": "Stub La Liga", "country": "ES"},
+            ]
+        return _real_leagues(self.cfg)
+
+    def fixtures_by_date(self, date_iso: str) -> list[dict[str, Any]]:
+        if self.cfg.stub:
+            return [
+                {"id": 101, "home": "Stub FC", "away": "Mock United", "date": date_iso},
+                {"id": 102, "home": "Sample City", "away": "Example Town", "date": date_iso},
+            ]
+        return _real_fixtures_by_date(self.cfg, date_iso)
+
+
+def _require_requests():
+    try:
+        import requests  # type: ignore
+
+        return requests
+    except Exception as e:  # pragma: no cover - defensive
+        raise RuntimeError("requests library required for real SportMonks calls") from e
+
+
+def _real_headers(cfg: SportMonksConfig) -> dict[str, str]:
+    if not cfg.api_key or cfg.api_key.lower() == "dummy":
+        raise RuntimeError("SPORTMONKS_API_KEY missing. Enable stub or set real key.")
+    return {"Authorization": f"Bearer {cfg.api_key}"}
+
+
+def _real_leagues(cfg: SportMonksConfig) -> list[dict[str, Any]]:
+    requests = _require_requests()
+    url = f"{cfg.base_url}/football/leagues"
+    r = requests.get(url, headers=_real_headers(cfg), timeout=10)
+    r.raise_for_status()
+    return r.json().get("data", [])
+
+
+def _real_fixtures_by_date(cfg: SportMonksConfig, date_iso: str) -> list[dict[str, Any]]:
+    requests = _require_requests()
+    url = f"{cfg.base_url}/football/fixtures/date/{date_iso}"
+    r = requests.get(url, headers=_real_headers(cfg), timeout=10)
+    r.raise_for_status()
+    return r.json().get("data", [])

--- a/docs/Project.md
+++ b/docs/Project.md
@@ -28,6 +28,8 @@ telegram-bot/
 ├─ logger.py                 | логирование (Loguru JSON + Sentry)
 ├─ observability.py          | инициализация Sentry и Prometheus
 ├─ app/
+│  ├─ integrations/
+│  │  └─ sportmonks_client.py     # STUB-aware SportMonks API client
 │  └─ data_processor/           | фасад старого data_processor.py
 │     ├─ __init__.py
 │     ├─ validators.py

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,12 @@
+## [2025-09-15] - SportMonks stub client and tests
+### Добавлено
+- Клиент SportMonks с режимом заглушки.
+- Тесты для проверки stub-логики.
+### Изменено
+- .env.example документирует переменную SPORTMONKS_STUB.
+### Исправлено
+- —
+
 ## [2025-09-15] - Add smoke tests and CI offline lint
 ### Добавлено
 - Smoke-тесты для базовых эндпоинтов.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: SportMonks stub client
+- **Статус**: Завершена
+- **Описание**: Добавить клиента SportMonks с режимом заглушки и тесты.
+- **Шаги выполнения**:
+  - [x] Реализовать клиента с режимом заглушки
+  - [x] Автоматически включать stub в тестах
+  - [x] Добавить юнит-тесты и обновить .env.example
+- **Зависимости**: app/integrations/sportmonks_client.py, tests/test_sportmonks_stub.py, .env.example
+
 ## Задача: Add endpoint smoke tests and offline lint in CI
 - **Статус**: Завершена
 - **Описание**: Добавить smoke-тесты /health, /metrics, /__smoke__/retrain, /__smoke__/sentry и обновить CI для использования make pre-commit-smart.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,16 @@ import sys
 import pytest
 
 
+# Автоматически включаем STUB-режим SportMonks для тестов,
+# если ключ отсутствует или равен "dummy".
+@pytest.fixture(autouse=True, scope="session")
+def _force_sportmonks_stub():
+    key = os.getenv("SPORTMONKS_API_KEY", "")
+    if (not key) or (key.lower() == "dummy"):
+        os.environ["SPORTMONKS_STUB"] = "1"
+    return
+
+
 def _numpy_stack_ok() -> bool:
     """
     Пытаемся импортировать numpy/pandas и сделать примитивные вызовы.

--- a/tests/test_sportmonks_stub.py
+++ b/tests/test_sportmonks_stub.py
@@ -1,0 +1,28 @@
+"""
+@file: test_sportmonks_stub.py
+@description: Tests for SportMonks client stub behaviour
+@dependencies: app/integrations/sportmonks_client.py
+@created: 2025-09-15
+"""
+import os
+
+
+def test_stub_client(monkeypatch):
+    monkeypatch.setenv("SPORTMONKS_STUB", "1")
+    monkeypatch.delenv("SPORTMONKS_API_KEY", raising=False)
+    from app.integrations.sportmonks_client import SportMonksClient
+
+    client = SportMonksClient()
+    leagues = client.leagues()
+    assert isinstance(leagues, list)
+    assert len(leagues) >= 2
+    fixtures = client.fixtures_by_date("2025-01-01")
+    assert all("id" in f and "home" in f and "away" in f for f in fixtures)
+
+
+def test_stub_auto_enabled(monkeypatch):
+    monkeypatch.setenv("SPORTMONKS_API_KEY", "dummy")
+    from app.integrations.sportmonks_client import SportMonksConfig
+
+    cfg = SportMonksConfig.from_env()
+    assert cfg.stub


### PR DESCRIPTION
## Summary
- add SportMonks client supporting STUB mode for offline testing
- auto-enable stub in tests and document SPORTMONKS_STUB env var
- cover stub logic with unit tests and update docs

## Testing
- `pytest tests/test_sportmonks_stub.py`
- `pre-commit run --files app/integrations/__init__.py app/integrations/sportmonks_client.py tests/conftest.py tests/test_sportmonks_stub.py .env.example docs/changelog.md docs/tasktracker.md docs/Project.md` *(fails: unable to access remote; offline config invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ae5702e4832eb1e7f1768ebf3365