### PR TITLE
ci: add wheel cache and numeric enforcement docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ __pycache__/
 .ruff_cache/
 .cache/
 .tmp/
+# local wheel cache
+wheels/*.whl
 # black force-exclude offenders (appended by scripts/black_partition.py)
 /telegram/middlewares.py
 /telegram/models.py

--- a/.pre-commit-config.offline.yaml
+++ b/.pre-commit-config.offline.yaml
@@ -6,6 +6,11 @@
 repos:
   - repo: local
     hooks:
+      - id: ruff
+        name: ruff
+        entry: python -m ruff
+        language: system
+        types: [python]
       - id: black
         name: black
         entry: python -m black

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) and `docs/Project.md` for more details.
 Если `numpy` и `pandas` недоступны (например, в офлайн окружении),
 тесты, помеченные `@pytest.mark.needs_np`, будут автоматически пропущены.
 
+## CI numeric enforcement
+
+CI завершается с ошибкой, если любой тест с маркером `needs_np` был пропущен.
+Чтобы обеспечить прохождение сборки в офлайн-режиме, заранее
+подготовьте колёса в каталоге `wheels/` или настройте локальное зеркало PyPI
+через `pip.conf`. При отсутствии необходимых пакетов тесты будут SKIP и CI
+прервёт сборку.
+
 ## Tests
 
 - Контрактный тест сверяет `.env.example` с `app.config.Settings`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,14 @@
+## [2025-09-15] - Offline numeric stack support
+### Добавлено
+- Каталог `wheels/` и настройка `pip` для офлайн-установок.
+- Хук `ruff` в `.pre-commit-config.offline.yaml`.
+- Раздел README "CI numeric enforcement".
+### Изменено
+- `pip.conf` использует локальный кэш колёс.
+- `.pre-commit-config.offline.yaml` расширен `ruff`-хуком.
+### Исправлено
+- —
+
 ## [2025-09-15] - Enforce numeric test suite
 ### Добавлено
 - Жёсткая проверка `needs_np` тестов в CI.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,13 @@
+## Задача: Offline numeric stack support
+- **Статус**: Завершена
+- **Описание**: Настроить кеш колёс, расширить офлайн pre-commit ruff и задокументировать CI numeric enforcement.
+- **Шаги выполнения**:
+  - [x] Обновлён pip.conf с find-links и создан каталог wheels
+  - [x] Добавлен ruff в .pre-commit-config.offline.yaml
+  - [x] В README добавлен раздел CI numeric enforcement
+  - [x] Обновлены docs/changelog.md и docs/tasktracker.md
+- **Зависимости**: pip.conf, wheels/README.md, .pre-commit-config.offline.yaml, README.md, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: Numpy guard and CI fallback
 - **Статус**: Завершена
 - **Описание**: Добавить пропуск numpy/pandas тестов без стека, обновить CI и документацию.

--- a/pip.conf
+++ b/pip.conf
@@ -9,3 +9,6 @@ retries = 2
 # index-url = https://<YOUR_MIRROR>/simple
 # extra-index-url = https://pypi.org/simple
 prefer-binary = yes
+find-links = wheels
+# для полностью офлайн-режима раскомментируйте строку ниже
+# no-index = yes

--- a/wheels/README.md
+++ b/wheels/README.md
@@ -1,0 +1,9 @@
+<!--
+@file: README.md
+@description: Placeholder for prebuilt wheels used in offline installs
+@dependencies: pip.conf
+@created: 2025-09-15
+-->
+# wheels cache
+
+Place pre-built `.whl` packages here to enable offline installs.


### PR DESCRIPTION
## Summary
- configure `pip` to use a local `wheels/` cache for offline installs
- add `ruff` to the offline pre-commit config
- document CI numeric enforcement and offline dependency fallback

## Testing
- `pre-commit run --config .pre-commit-config.offline.yaml --files .gitignore .pre-commit-config.offline.yaml README.md docs/changelog.md docs/tasktracker.md pip.conf wheels/README.md`
- `SPORTMONKS_API_KEY=dummy SPORTMONKS_STUB=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7c57bea5c832eacbe2b3c0bd9d2f3