### PR TITLE
fix(lint): resolve Ruff F401/I001/UP037/UP035/UP045 warnings

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,11 @@
+## [2025-09-15] - Ruff warnings cleanup
+### Добавлено
+- —
+### Изменено
+- Аннотации типов в prediction_pipeline и retrain_scheduler используют современный синтаксис.
+### Исправлено
+- Предупреждения Ruff F401, I001, UP037, UP035, UP045.
+
 ## [2025-09-15] - Ruff leftovers cleanup and smoke
 ### Добавлено
 - —

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: Ruff warnings cleanup
+- **Статус**: Завершена
+- **Описание**: Устранить предупреждения Ruff F401/I001/UP037/UP035/UP045.
+- **Шаги выполнения**:
+  - [x] Удалены неиспользуемые импорты и упорядочены импорты.
+  - [x] Обновлены аннотации типов на современный синтаксис.
+  - [x] Прогнаны pre-commit, линты и тесты.
+- **Зависимости**: scripts/syntax_partition.py, tests/test_ml.py, services/prediction_pipeline.py, workers/retrain_scheduler.py, docs/changelog.md, docs/tasktracker.md, reports/RUN_SUMMARY.md
+
 ## Задача: Fix Ruff leftovers and verbose smoke
 - **Статус**: Завершена
 - **Описание**: Устранить предупреждения Ruff B904/C401/ERA001 и сделать цель smoke говорящей.

--- a/reports/RUN_SUMMARY.md
+++ b/reports/RUN_SUMMARY.md
@@ -1,10 +1,10 @@
 # Run Summary (2025-09-15)
 
 ## Applied Tasks
-- Fix Ruff leftovers and verbose smoke
+- Ruff warnings cleanup
 
 ## Lint
-- pre-commit (offline) – ⚠️ hooks modified files (ruff-check, black, trailing-whitespace, end-of-file-fixer)
+- pre-commit (offline) – OK (ruff-check, black, isort, trailing-whitespace, end-of-file-fixer)
 - make lint-app – pass
 - make lint – pass
 
@@ -17,15 +17,7 @@
   - /__smoke__/retrain.jobs_registered_total → 0.0
 
 ## Ruff Leftovers
-- F401 scripts/syntax_partition.py:8
-- F401 scripts/syntax_partition.py:9
-- UP037 services/prediction_pipeline.py:18
-- UP037 services/prediction_pipeline.py:18 (return type)
-- UP037 services/prediction_pipeline.py:53
-- I001 tests/test_ml.py:7
-- UP035 workers/retrain_scheduler.py:10
-- UP045 workers/retrain_scheduler.py:33
-- UP045 workers/retrain_scheduler.py:34
+- none
 
 ## Next Steps
-- Address remaining Ruff warnings.
+- —

--- a/scripts/syntax_partition.py
+++ b/scripts/syntax_partition.py
@@ -1,12 +1,10 @@
 # @file: scripts/syntax_partition.py
 # @description: Split parseable and non-parseable app python files, update ignore lists, and emit lint targets
-# @dependencies: pathlib, sys, subprocess
+# @dependencies: pathlib
 # @created: 2025-09-12
 from __future__ import annotations
 
 import pathlib
-import subprocess
-import sys
 
 ROOT = pathlib.Path(".").resolve()
 

--- a/services/prediction_pipeline.py
+++ b/services/prediction_pipeline.py
@@ -4,8 +4,6 @@
 @dependencies: pandas (optional), numpy (optional), Preprocessor, ModelRegistry
 @created: 2025-09-12
 """
-from __future__ import annotations
-
 from typing import Any, Protocol
 
 try:  # optional import for constrained environments
@@ -15,11 +13,13 @@ except Exception:  # pragma: no cover
 
 
 class Preprocessor(Protocol):
-    def transform(self, df: "pd.DataFrame") -> "pd.DataFrame": ...
+    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
+        ...
 
 
 class ModelRegistry(Protocol):
-    def load(self, name: str): ...
+    def load(self, name: str):
+        ...
 
 
 class _DummyModel:
@@ -50,7 +50,7 @@ class PredictionPipeline:
         m = self._reg.load("current")
         return m or _DummyModel()
 
-    def predict_proba(self, df: "pd.DataFrame"):
+    def predict_proba(self, df: pd.DataFrame):
         X = self._pre.transform(df)
         model = self._load_model()
         if hasattr(model, "predict_proba"):

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import pytest
+
 pytest.importorskip("numpy")
 pytest.importorskip("pandas")
 

--- a/workers/retrain_scheduler.py
+++ b/workers/retrain_scheduler.py
@@ -4,10 +4,8 @@
 @dependencies: os, optional training task
 @created: 2025-09-12
 """
-from __future__ import annotations
-
 import os
-from typing import Callable, Optional
+from collections.abc import Callable
 
 
 def _default_task():
@@ -30,8 +28,8 @@ def _default_task():
 
 def schedule_retrain(
     register: Callable[[str, Callable[[], None]], None],
-    cron_expr: Optional[str] = None,
-    task: Optional[Callable[[], None]] = None,
+    cron_expr: str | None = None,
+    task: Callable[[], None] | None = None,
 ) -> str:
     """
     Register periodic retrain job.


### PR DESCRIPTION
## Summary
- remove unused imports in syntax partition script
- reorder test imports for deterministic linting
- adopt modern typing for prediction pipeline and retrain scheduler

## Testing
- `pre-commit run --config .pre-commit-config.offline.yaml --files scripts/syntax_partition.py services/prediction_pipeline.py tests/test_ml.py workers/retrain_scheduler.py docs/changelog.md docs/tasktracker.md reports/RUN_SUMMARY.md`
- `make lint-app && make lint`
- `pytest -q`
- `pytest -q -m needs_np`
- `make smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c7dc35a350832eb7b60394bb497617