### PR TITLE
feat(core): add entropy analytics and simulation settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@ RATE_LIMIT_PER_SECONDS=60
 MODEL_REGISTRY_PATH=artifacts/
 RETRAIN_CRON=""
 SEASON_ID=23855  # default season for training script
+SIM_RHO=0.1
+SIM_N=10000
+SIM_CHUNK=100000
 
 # Services/Workers
 # prediction pipeline и планировщик будут читать эти значения при инициализации

--- a/app/config.py
+++ b/app/config.py
@@ -56,6 +56,9 @@ class Settings(BaseSettings):
     prometheus: PrometheusSettings = PrometheusSettings()
     git_sha: str = Field(default="dev", alias="GIT_SHA")
     rate_limit: RateLimitSettings = RateLimitSettings()
+    sim_rho: float = Field(default=0.1, alias="SIM_RHO")
+    sim_n: int = Field(default=10000, alias="SIM_N")
+    sim_chunk: int = Field(default=100000, alias="SIM_CHUNK")
 
 
 @lru_cache(1)

--- a/config.py
+++ b/config.py
@@ -74,6 +74,11 @@ class Settings(BaseSettings):
         "enable_calibration": True,
     }
 
+    # --- Simulation ---
+    SIM_RHO: float = 0.1
+    SIM_N: int = 10000
+    SIM_CHUNK: int = 100000
+
     # --- Динамические поля ---
     @computed_field  # Генерируется на основе других полей
     @property

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,13 @@
+## [2025-09-15] - Entropy analytics and simulation settings
+### Добавлено
+- Модуль `ml/metrics/entropy.py` и тесты.
+- Параметры окружения `SIM_RHO`, `SIM_N`, `SIM_CHUNK`.
+- Энтропии рынков в `services/simulator.py`.
+### Изменено
+- `.env.example`, `config.py`, `app/config.py`, `ml/sim/bivariate_poisson.py`.
+### Исправлено
+- —
+
 ## [2025-09-15] - Simulation markets and calibration
 ### Добавлено
 - Bi-Poisson simulator with correlated goals and market aggregations (1x2, totals, BTTS, CS).

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: Entropy analytics and simulation settings
+- **Статус**: В процессе
+- **Описание**: Добавить расчёт энтропии рынков и параметры симуляции.
+- **Шаги выполнения**:
+  - [x] Реализован модуль энтропии и тесты.
+  - [x] Добавлены переменные окружения и настройки.
+  - [ ] Интеграция в prediction_pipeline и отчёты.
+- **Зависимости**: services/simulator.py, ml/metrics/entropy.py, config.py, app/config.py, .env.example, ml/sim/bivariate_poisson.py
+
 ## Задача: Ruff warnings cleanup
 - **Статус**: Завершена
 - **Описание**: Устранить предупреждения Ruff F401/I001/UP037/UP035/UP045.

--- a/ml/metrics/__init__.py
+++ b/ml/metrics/__init__.py
@@ -1,0 +1,6 @@
+"""
+@file: __init__.py
+@description: Metrics utilities package.
+@dependencies: none
+@created: 2025-09-18
+"""

--- a/ml/metrics/entropy.py
+++ b/ml/metrics/entropy.py
@@ -1,0 +1,34 @@
+"""
+@file: entropy.py
+@description: Shannon entropy helpers for simulation markets.
+@dependencies: numpy
+@created: 2025-09-18
+"""
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+
+
+def shannon_entropy(p: Iterable[float]) -> float:
+    """Compute Shannon entropy in bits avoiding log(0)."""
+    total = 0.0
+    for prob in p:
+        if prob > 0:
+            total -= prob * math.log2(prob)
+    return total
+
+
+def entropy_1x2(p1: float, px: float, p2: float) -> dict[str, float]:
+    """Entropy for 1X2 market."""
+    return {"1x2": shannon_entropy([p1, px, p2])}
+
+
+def entropy_totals(p_over: float, p_under: float) -> dict[str, float]:
+    """Entropy for totals market (single line)."""
+    return {"totals": shannon_entropy([p_over, p_under])}
+
+
+def entropy_cs(cs_probs: dict[str, float]) -> dict[str, float]:
+    """Entropy for correct score market."""
+    return {"cs": shannon_entropy(cs_probs.values())}

--- a/services/simulator.py
+++ b/services/simulator.py
@@ -1,7 +1,7 @@
 """
 @file: simulator.py
-@description: Monte-Carlo simulator for football markets.
-@dependencies: numpy, collections
+@description: Monte-Carlo simulator for football markets with entropy analytics.
+@dependencies: numpy, collections, ml.metrics.entropy
 @created: 2025-09-15
 """
 from __future__ import annotations
@@ -11,6 +11,7 @@ from typing import Any
 
 import numpy as np
 
+from ml.metrics.entropy import entropy_1x2, entropy_cs, entropy_totals
 from ml.sim.bivariate_poisson import simulate_bipoisson
 
 
@@ -54,6 +55,13 @@ class Simulator:
         cs["OTHER"] = other_prob
         markets["cs"] = cs
 
+        ent: dict[str, float] = {}
+        ent.update(entropy_1x2(win1, draw, win2))
+        main_total = totals.get("2.5") or next(iter(totals.values()))
+        ent.update(entropy_totals(main_total["over"], main_total["under"]))
+        ent.update(entropy_cs(cs))
+        markets["entropy"] = ent
+
         if return_samples:
             return markets, home, away
         return markets
@@ -64,3 +72,20 @@ class Simulator:
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             json.dump(result, f, ensure_ascii=False, indent=2)
+
+
+def render_markdown(markets: dict[str, Any]) -> str:
+    """Render markets and entropies into a Markdown table."""
+    lines = ["|Market|Selection|Prob|", "|---|---|---|"]
+    for sel, prob in markets.get("1x2", {}).items():
+        lines.append(f"|1X2|{sel}|{prob:.4f}|")
+    if "totals" in markets:
+        mt = markets["totals"].get("2.5") or next(iter(markets["totals"].values()))
+        for sel, prob in mt.items():
+            lines.append(f"|totals 2.5|{sel}|{prob:.4f}|")
+    for sel, prob in markets.get("btts", {}).items():
+        lines.append(f"|btts|{sel}|{prob:.4f}|")
+    lines.append(f"|entropy|1x2|{markets['entropy']['1x2']:.4f}|")
+    lines.append(f"|entropy|totals|{markets['entropy']['totals']:.4f}|")
+    lines.append(f"|entropy|cs|{markets['entropy']['cs']:.4f}|")
+    return "\n".join(lines)

--- a/tests/ml/test_entropy.py
+++ b/tests/ml/test_entropy.py
@@ -1,0 +1,31 @@
+"""
+@file: test_entropy.py
+@description: Tests for entropy helpers.
+@dependencies: pytest, numpy
+@created: 2025-09-18
+"""
+import pytest
+
+from ml.metrics.entropy import entropy_1x2, entropy_cs, entropy_totals, shannon_entropy
+
+
+@pytest.mark.needs_np
+def test_entropy_uniform_maximum():
+    uniform = shannon_entropy([1 / 3, 1 / 3, 1 / 3])
+    skewed = shannon_entropy([0.8, 0.1, 0.1])
+    assert uniform > skewed
+    e1 = entropy_1x2(1 / 3, 1 / 3, 1 / 3)["1x2"]
+    assert e1 == pytest.approx(uniform)
+
+
+@pytest.mark.needs_np
+def test_entropy_handles_zero():
+    assert shannon_entropy([1.0, 0.0]) == 0.0
+    ecs = entropy_cs({"1:0": 1.0, "0:0": 0.0})["cs"]
+    assert ecs == 0.0
+
+
+@pytest.mark.needs_np
+def test_entropy_totals_normalization():
+    et = entropy_totals(0.5, 0.5)["totals"]
+    assert et == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- add SIM_RHO, SIM_N, SIM_CHUNK settings with defaults
- implement entropy helpers and integrate into simulator
- document entropy work and tracking entries

## Testing
- `pre-commit run -c .pre-commit-config.offline.yaml --files .env.example app/config.py config.py docs/changelog.md docs/tasktracker.md ml/sim/bivariate_poisson.py services/simulator.py ml/metrics/__init__.py ml/metrics/entropy.py tests/ml/test_entropy.py || true`
- `pre-commit run -c .pre-commit-config.offline.yaml --all-files || true`
- `make lint-app && make lint || true`
- `pytest -q`
- `pytest -q -m needs_np`
- `make smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c7f1d2bb70832ea21420b2b7a328c7