### PR TITLE
feat(pipeline): integrate simulation with reports and storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,13 @@ jobs:
           TOL_ECE: "0.00"
         run: |
           python scripts/validate_modifiers.py --season-id "${SEASON_ID}" --input data/val.csv --alpha 0.005 --l2 1.0 --tol "${TOL_LOSS}" --tol-ece "${TOL_ECE}"
+      - name: Upload simulation artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: metrics-and-artifacts
+          path: |
+            reports/metrics/**/*.md
+            reports/metrics/**/*.png
+            artifacts/**/*
+            var/predictions.sqlite
+          retention-days: 14

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,7 +34,9 @@ See `docs/Project.md` for a detailed design.
 
 `services/simulator.py` uses `ml/sim/bivariate_poisson.py` to generate correlated
 scores. Aggregators expose markets 1x2, totals (0.5–5.5), BTTS and correct
-score grid 0..6 with tail `OTHER`.
+score grid 0..6 with tail `OTHER`. The prediction pipeline calls the simulator
+after computing final λ and persists markets to SQLite and Markdown report.
+Parameters are configurable via `SIM_RHO`, `SIM_N`, `SIM_CHUNK`.
 
 ## Storage
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ python scripts/run_simulation.py --season-id default --home H --away A --rho 0.1
 Predictions are stored via SQLite fallback (`storage/persistence.py`).
 Table `predictions(match_id, market, selection, prob, ts, season, extra)`.
 DB path is taken from `PREDICTIONS_DB_URL` (defaults to `var/predictions.sqlite`).
+Each pipeline run also writes a Markdown report
+`reports/metrics/SIM_{SEASON}_{home}_vs_{away}.md` with entropy stats.
+Control parameters via environment variables:
+
+- `SIM_RHO` – correlation coefficient (default `0.1`)
+- `SIM_N` – number of simulations (default `10000`)
+- `SIM_CHUNK` – chunk size for vectorized draws (default `100000`)
 
 ## Services & Workers (скелеты)
 
@@ -82,6 +89,7 @@ DB path is taken from `PREDICTIONS_DB_URL` (defaults to `var/predictions.sqlite`
 - `MODEL_REGISTRY_PATH` — каталог LocalModelRegistry (по умолчанию `artifacts/`).
 - `RETRAIN_CRON` — crontab для планировщика (пусто/`off` выключает).
 - `SEASON_ID` — сезон для скрипта обучения (по умолчанию `23855`).
+- `SIM_RHO`, `SIM_N`, `SIM_CHUNK` — параметры симуляции (корреляция, число прогонов и размер чанка).
 
 ## Modifiers validation
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,12 @@
+## [2025-09-15] - Simulation pipeline integration
+### Добавлено
+- Monte-Carlo simulation integrated into prediction pipeline with SQLite writes and Markdown reports.
+- CI uploads simulation artifacts and integration test ensures markets are persisted.
+### Изменено
+- README.md, ARCHITECTURE.md, reports/RUN_SUMMARY.md.
+### Исправлено
+- —
+
 ## [2025-09-15] - Entropy analytics and simulation settings
 ### Добавлено
 - Модуль `ml/metrics/entropy.py` и тесты.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,10 +1,10 @@
-## Задача: Entropy analytics and simulation settings
-- **Статус**: В процессе
+## Задача: Монте-Карло и Bi-Poisson
+- **Статус**: Завершена
 - **Описание**: Добавить расчёт энтропии рынков и параметры симуляции.
 - **Шаги выполнения**:
   - [x] Реализован модуль энтропии и тесты.
   - [x] Добавлены переменные окружения и настройки.
-  - [ ] Интеграция в prediction_pipeline и отчёты.
+  - [x] Интеграция в prediction_pipeline и отчёты.
 - **Зависимости**: services/simulator.py, ml/metrics/entropy.py, config.py, app/config.py, .env.example, ml/sim/bivariate_poisson.py
 
 ## Задача: Ruff warnings cleanup

--- a/reports/RUN_SUMMARY.md
+++ b/reports/RUN_SUMMARY.md
@@ -18,10 +18,10 @@
 - pytest tests/storage/test_predictions_store.py -q – pass
 - pytest tests/smoke/test_run_simulation_cli.py -q – pass
 
-## Simulation
-- n_sims: 10000, rho: 0.1
-- markets: 1x2, totals, btts, cs
-- ECE report: reports/metrics/ECE_simulation_default_H_vs_A.md
+## Simulation Integration
+- n_sims: 512, rho: 0.1
+- entropy: 1x2=1.5798, totals=0.9189, cs=3.7127
+- report: reports/metrics/SIM_S_H_vs_A.md
 - SQLite: var/predictions.sqlite
 
 ## Next Steps

--- a/tests/integration/test_pipeline_writes_markets.py
+++ b/tests/integration/test_pipeline_writes_markets.py
@@ -1,0 +1,67 @@
+"""
+@file: test_pipeline_writes_markets.py
+@description: Integration test verifying PredictionPipeline writes simulated markets.
+@dependencies: pandas, services/prediction_pipeline, sqlite3
+@created: 2025-09-15
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from app.config import reset_settings_cache
+from services.prediction_pipeline import PredictionPipeline
+
+
+@pytest.mark.needs_np
+def test_pipeline_writes_markets(tmp_path, monkeypatch):
+    class _Pre:
+        def transform(self, df: pd.DataFrame) -> pd.DataFrame:  # noqa: D401
+            return df[[]]
+
+    monkeypatch.setenv("PREDICTIONS_DB_URL", str(tmp_path / "pred.sqlite"))
+    monkeypatch.setenv("SIM_N", "512")
+    reset_settings_cache()
+
+    df = pd.DataFrame(
+        {
+            "home": ["H"],
+            "away": ["A"],
+            "season": ["S"],
+            "date": [pd.Timestamp("2024-01-01")],
+        }
+    )
+
+    pipe = PredictionPipeline(_Pre())
+    pipe.predict_proba(df)
+
+    conn = sqlite3.connect(tmp_path / "pred.sqlite")
+    rows = conn.execute("SELECT market, selection, prob FROM predictions").fetchall()
+    conn.close()
+    assert any(m == "1x2" for m, _, _ in rows)
+    assert any(m.startswith("totals_") for m, _, _ in rows)
+    assert any(m == "btts" for m, _, _ in rows)
+    assert any(m == "cs" for m, _, _ in rows)
+
+    sum_1x2 = sum(prob for m, _, prob in rows if m == "1x2")
+    assert pytest.approx(1.0, rel=1e-2) == sum_1x2
+
+    totals = {}
+    for m, sel, prob in rows:
+        if m.startswith("totals_"):
+            thr = m.split("_", 1)[1]
+            totals.setdefault(thr, {}).update({sel: prob})
+    for sp in totals.values():
+        assert pytest.approx(1.0, rel=1e-2) == sp.get("over", 0) + sp.get("under", 0)
+
+    sum_cs = sum(prob for m, _, prob in rows if m == "cs")
+    assert pytest.approx(1.0, rel=1e-2) == sum_cs
+
+    report = Path("reports/metrics/SIM_S_H_vs_A.md")
+    assert report.exists()
+    content = report.read_text(encoding="utf-8")
+    assert "### Entropy" in content


### PR DESCRIPTION
## Summary
- integrate Monte Carlo simulator into prediction pipeline with SQLite persistence and markdown reports
- publish simulation artifacts in CI and document SIM_* environment settings
- add integration test verifying markets write-out

## Testing
- `pre-commit run -c .pre-commit-config.offline.yaml --files .github/workflows/ci.yml ARCHITECTURE.md README.md docs/changelog.md docs/tasktracker.md reports/RUN_SUMMARY.md services/prediction_pipeline.py services/simulator.py tests/integration/test_pipeline_writes_markets.py`
- `make lint-app && make lint || true`
- `pytest -q`
- `pytest -q -m needs_np`
- `make smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c7f42f9228832eb9b16b35e6022c10