### PR TITLE
feat: integrate data processor pipeline

### DIFF
--- a/app/data_processor/__init__.py
+++ b/app/data_processor/__init__.py
@@ -1,13 +1,18 @@
 """
 @file: __init__.py
-@description: Facade for the data_processor package with backward compatibility.
-@dependencies: data_processor legacy module
-@created: 2025-09-10
-"""
-# Фасад: импортируем из старого модуля для обратной совместимости
-import data_processor as legacy
+@description: Public interface for the data processor scaffolding.
+@dependencies: pandas
+@created: 2025-09-16
 
-from .feature_engineering import build_features
-from .io import load_data, save_data
-from .transformers import make_transformers
-from .validators import validate_required_columns
+Top-level package for the upcoming data processor implementation.
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from .features import build_features
+from .matrix import to_model_matrix
+from .validate import validate_input
+
+__all__ = ("__version__", "build_features", "to_model_matrix", "validate_input")

--- a/app/data_processor/features.py
+++ b/app/data_processor/features.py
@@ -1,0 +1,129 @@
+"""
+@file: features.py
+@description: Feature construction utilities for the unified data processor package.
+@dependencies: pandas, numpy
+@created: 2025-09-16
+
+Feature engineering helpers that expand validated match data into team specific rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+
+_EMPTY_ERROR = "Cannot build features from an empty dataframe."
+
+
+def _normalise_windows(windows: Iterable[int]) -> tuple[int, ...]:
+    cleaned: list[int] = []
+    for window in windows:
+        try:
+            value = int(window)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("rolling windows must be integers") from exc
+        if value <= 0:
+            raise ValueError("rolling windows must be positive integers")
+        cleaned.append(value)
+    return tuple(dict.fromkeys(sorted(cleaned)))
+
+
+def _compute_rest_days(features: pd.DataFrame) -> None:
+    rest = (
+        features.sort_values(["team", "date", "is_home"])
+        .groupby("team")["date"]
+        .diff()
+        .dt.days
+    )
+    rest = rest.fillna(14).clip(lower=0, upper=14)
+    features["rest_days"] = rest.astype(int)
+
+
+def _apply_rolling(features: pd.DataFrame, windows: tuple[int, ...]) -> None:
+    grouped = features.sort_values(["team", "is_home", "date"]).groupby(
+        ["team", "is_home"], group_keys=False
+    )
+    for window in windows:
+        col_for = f"rolling_xg_for_{window}"
+        col_against = f"rolling_xg_against_{window}"
+        features[col_for] = grouped["xg_for"].transform(
+            lambda s, w=window: s.shift().rolling(window=w, min_periods=1).mean()
+        )
+        features[col_against] = grouped["xg_against"].transform(
+            lambda s, w=window: s.shift().rolling(window=w, min_periods=1).mean()
+        )
+
+    rolling_cols = [c for c in features.columns if c.startswith("rolling_xg_")]
+    if rolling_cols:
+        features[rolling_cols] = features[rolling_cols].fillna(0.0)
+
+
+def build_features(df: pd.DataFrame, *, windows: Iterable[int] = (5, 10)) -> pd.DataFrame:
+    """Construct rolling window features for each team and role.
+
+    Args:
+        df: Validated dataframe.
+        windows: Iterable with rolling window sizes for aggregations.
+
+    Returns:
+        Dataframe expanded to team specific rows with engineered features.
+
+    Raises:
+        ValueError: If the dataframe is empty or configuration is invalid.
+    """
+
+    if df.empty:
+        raise ValueError(_EMPTY_ERROR)
+
+    window_sizes = _normalise_windows(windows)
+    base = df.copy().reset_index(drop=True)
+    base["match_id"] = base.index
+
+    home = base.assign(
+        team=base["home_team"],
+        opponent=base["away_team"],
+        is_home=1,
+        xg_for=base["xG_home"],
+        xg_against=base["xG_away"],
+    )
+    away = base.assign(
+        team=base["away_team"],
+        opponent=base["home_team"],
+        is_home=0,
+        xg_for=base["xG_away"],
+        xg_against=base["xG_home"],
+    )
+
+    features = pd.concat([home, away], ignore_index=True, copy=False)
+    features["is_home"] = features["is_home"].astype(int)
+    features["team"] = features["team"].astype(str)
+    features["opponent"] = features["opponent"].astype(str)
+
+    _compute_rest_days(features)
+    _apply_rolling(features, window_sizes)
+
+    column_order = [
+        "match_id",
+        "date",
+        "team",
+        "opponent",
+        "is_home",
+        "rest_days",
+        "xg_for",
+        "xg_against",
+        "goals_home",
+        "goals_away",
+    ]
+    rolling_cols = [c for c in features.columns if c.startswith("rolling_xg_")]
+    for column in rolling_cols:
+        if column not in column_order:
+            column_order.append(column)
+
+    remaining = [c for c in features.columns if c not in column_order]
+    column_order.extend(remaining)
+
+    features = features[column_order].sort_values(["match_id", "is_home", "date"]).reset_index(
+        drop=True
+    )
+    return features

--- a/app/data_processor/matrix.py
+++ b/app/data_processor/matrix.py
@@ -1,0 +1,74 @@
+"""
+@file: matrix.py
+@description: Model matrix helpers for converting engineered features to GLM inputs.
+@dependencies: pandas
+@created: 2025-09-16
+
+Helpers for constructing the modelling matrices for home and away Poisson GLMs.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Iterable
+
+import pandas as pd
+
+_EMPTY_ERROR = "Cannot prepare a model matrix from an empty dataframe."
+_REQUIRED_FEATURE_COLUMNS: Final[set[str]] = {"is_home", "goals_home", "goals_away", "rest_days"}
+
+ModelMatrix = tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]
+
+
+def _select_feature_columns(df: pd.DataFrame) -> list[str]:
+    feature_cols: list[str] = []
+    if "rest_days" in df.columns:
+        feature_cols.append("rest_days")
+    rolling_cols = sorted(
+        col for col in df.columns if col.startswith("rolling_xg_for_") or col.startswith("rolling_xg_against_")
+    )
+    feature_cols.extend(rolling_cols)
+    return feature_cols
+
+
+def _prepare_design_matrix(df: pd.DataFrame, columns: Iterable[str]) -> pd.DataFrame:
+    matrix = df.loc[:, list(columns)].copy().astype(float)
+    matrix.insert(0, "bias", 1.0)
+    return matrix
+
+
+def to_model_matrix(df: pd.DataFrame) -> ModelMatrix:
+    """Convert engineered features into modelling matrices for home and away teams.
+
+    Args:
+        df: Dataframe with engineered features returned by :func:`build_features`.
+
+    Returns:
+        Tuple containing design matrices and targets for home and away GLMs.
+
+    Raises:
+        ValueError: If the dataframe is empty or missing required columns.
+    """
+
+    if df.empty:
+        raise ValueError(_EMPTY_ERROR)
+
+    missing = _REQUIRED_FEATURE_COLUMNS - set(df.columns)
+    if missing:
+        raise ValueError(f"missing required feature columns: {', '.join(sorted(missing))}")
+
+    feature_columns = _select_feature_columns(df)
+    if not feature_columns:
+        raise ValueError("no feature columns available for model matrix construction")
+
+    home_mask = df["is_home"] == 1
+    away_mask = df["is_home"] == 0
+    if not home_mask.any() or not away_mask.any():
+        raise ValueError("feature dataframe must contain both home and away rows")
+
+    X_home = _prepare_design_matrix(df.loc[home_mask], feature_columns).reset_index(drop=True)
+    y_home = df.loc[home_mask, "goals_home"].reset_index(drop=True).astype(int)
+
+    X_away = _prepare_design_matrix(df.loc[away_mask], feature_columns).reset_index(drop=True)
+    y_away = df.loc[away_mask, "goals_away"].reset_index(drop=True).astype(int)
+
+    return X_home, y_home, X_away, y_away

--- a/app/data_processor/validate.py
+++ b/app/data_processor/validate.py
@@ -1,0 +1,98 @@
+"""
+@file: validate.py
+@description: Input validation helpers for the consolidated data processor pipeline.
+@dependencies: pandas, numpy
+@created: 2025-09-16
+
+Validation helpers for match-level raw datasets that feed the feature builder.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Iterable
+
+import numpy as np
+import pandas as pd
+
+_EMPTY_ERROR: Final[str] = "Input dataframe is empty; validation requires source data."
+_REQUIRED_COLUMNS: Final[tuple[str, ...]] = (
+    "home_team",
+    "away_team",
+    "date",
+    "xG_home",
+    "xG_away",
+    "goals_home",
+    "goals_away",
+)
+_TEAM_COLUMNS: Final[tuple[str, str]] = ("home_team", "away_team")
+_XG_COLUMNS: Final[tuple[str, str]] = ("xG_home", "xG_away")
+_GOAL_COLUMNS: Final[tuple[str, str]] = ("goals_home", "goals_away")
+
+
+def _ensure_columns(df: pd.DataFrame, required: Iterable[str]) -> None:
+    missing = [col for col in required if col not in df.columns]
+    if missing:
+        raise ValueError(f"missing required columns: {', '.join(missing)}")
+
+
+def _validate_team_columns(df: pd.DataFrame) -> None:
+    for column in _TEAM_COLUMNS:
+        if df[column].isnull().any():
+            raise ValueError(f"team column '{column}' contains null values")
+        coerced = df[column].astype(str).str.strip()
+        if (coerced == "").any():
+            raise ValueError(f"team column '{column}' contains empty strings")
+        df[column] = coerced
+
+
+def _validate_numeric(df: pd.DataFrame, columns: Iterable[str], *, integer: bool = False) -> None:
+    for column in columns:
+        series = pd.to_numeric(df[column], errors="coerce")
+        if series.isnull().any():
+            raise ValueError(f"column '{column}' must be numeric")
+        if (series < 0).any():
+            raise ValueError(f"column '{column}' must be non-negative")
+        if integer:
+            if not np.all(np.isclose(series, series.round())):
+                raise ValueError(f"column '{column}' must contain integer values")
+            series = series.round().astype(int)
+        df[column] = series
+
+
+def _validate_date(df: pd.DataFrame) -> None:
+    converted = pd.to_datetime(df["date"], errors="coerce", utc=False)
+    if converted.isnull().any():
+        raise ValueError("column 'date' must contain valid datetime values")
+    df["date"] = converted.dt.tz_localize(None)
+
+
+def validate_input(df: pd.DataFrame) -> pd.DataFrame:
+    """Validate and normalise a raw dataframe prior to feature engineering.
+
+    Args:
+        df: Raw dataframe with match level observations.
+
+    Returns:
+        A validated dataframe copy with consistent dtypes.
+
+    Raises:
+        ValueError: If the dataframe is empty or violates schema constraints.
+    """
+
+    if df.empty:
+        raise ValueError(_EMPTY_ERROR)
+
+    df = df.copy()
+    _ensure_columns(df, _REQUIRED_COLUMNS)
+    _validate_date(df)
+    _validate_team_columns(df)
+    _validate_numeric(df, _XG_COLUMNS, integer=False)
+    _validate_numeric(df, _GOAL_COLUMNS, integer=True)
+
+    duplicates = df.duplicated(subset=["home_team", "away_team", "date"], keep=False)
+    if duplicates.any():
+        duplicated_rows = df.loc[duplicates, ["home_team", "away_team", "date"]]
+        formatted = duplicated_rows.to_dict(orient="records")
+        raise ValueError(f"duplicate match entries detected: {formatted}")
+
+    return df.reset_index(drop=True)

--- a/docs/Project.md
+++ b/docs/Project.md
@@ -30,12 +30,15 @@ telegram-bot/
 ├─ app/
 │  ├─ integrations/
 │  │  └─ sportmonks_client.py     # STUB-aware SportMonks API client
-│  └─ data_processor/           | фасад старого data_processor.py
+│  └─ data_processor/           | валидация и построение признаков матчей
 │     ├─ __init__.py
-│     ├─ validators.py
-│     ├─ feature_engineering.py
-│     ├─ transformers.py
-│     └─ io.py
+│     ├─ validate.py            # Проверка схемы, типов и дубликатов матчей
+│     ├─ features.py            # rest_days и rolling xG по команде и роли
+│     ├─ matrix.py              # Матрицы X/y для home/away GLM
+│     ├─ validators.py          # Legacy-обёртка на `data_processor.py`
+│     ├─ feature_engineering.py # Legacy-обёртка на `data_processor.py`
+│     ├─ transformers.py        # Legacy-обёртка на `data_processor.py`
+│     └─ io.py                  # Legacy-обёртка на `data_processor.py`
 ├─ metrics/                  | ECE/LogLoss метрики
 │  └─ metrics.py
 ├─ database/                 | PostgreSQL+Redis, миграции

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,22 @@
+## [2025-09-17] - Data processor integration
+### Добавлено
+- Реализация `validate_input`, `build_features`, `to_model_matrix` с расчётом rest_days и rolling xG.
+### Изменено
+- Скрипты `train_glm.py` и `train_modifiers.py` используют конвейер `app.data_processor`.
+- `services/prediction_pipeline.py` готовит признаки через `validate_input`/`build_features` и передаёт их модификаторам.
+- ML-тесты обновлены под новый формат данных и признаков.
+### Исправлено
+- Согласован расчёт метрик с обновлёнными целями `goals_home`/`goals_away`.
+
+## [2025-09-16] - Data processor scaffolding
+### Добавлено
+- Заглушечный пакет `app/data_processor` с модулями `validate`, `features`, `matrix` и версией пакета.
+- Тесты `tests/data_processor` на проверку ошибок при пустом `DataFrame`.
+### Изменено
+- Обновлён интерфейс `app.data_processor` для экспорта новых заглушек.
+### Исправлено
+- —
+
 ## [2025-09-15] - Release candidate v1.0.0-rc1
 ### Добавлено
 - APP_VERSION field and version labels in metrics and reports.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,21 @@
+## Задача: Data processor integration
+- **Статус**: Завершена
+- **Описание**: Подключить реализованный `app.data_processor` к обучению и инференсу моделей.
+- **Шаги выполнения**:
+  - [x] Реализованы проверки и признаки в `validate_input`, `build_features`, `to_model_matrix`.
+  - [x] Скрипты `train_glm.py` и `train_modifiers.py` используют новый конвейер подготовки данных.
+  - [x] PredictionPipeline и тесты обновлены под формат `goals_home`/`goals_away` и новые признаки.
+- **Зависимости**: app/data_processor/*, scripts/train_glm.py, scripts/train_modifiers.py, services/prediction_pipeline.py, tests/ml/
+
+## Задача: Data processor scaffolding
+- **Статус**: Завершена
+- **Описание**: Подготовить каркас пакета `app/data_processor` без миграции существующей логики.
+- **Шаги выполнения**:
+  - [x] Созданы модули validate/features/matrix с заглушками и аннотациями.
+  - [x] Обновлён `__init__.py` с версией пакета и экспортами.
+  - [x] Добавлены тесты на отказ при пустом `DataFrame`.
+- **Зависимости**: app/data_processor, tests/data_processor
+
 ## Задача: Монте-Карло и Bi-Poisson
 - **Статус**: Завершена
 - **Описание**: Добавить расчёт энтропии рынков и параметры симуляции.

--- a/scripts/train_modifiers.py
+++ b/scripts/train_modifiers.py
@@ -8,10 +8,16 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import sys
 
 import numpy as np
 import pandas as pd
 
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.data_processor import build_features, validate_input
 from ml.modifiers_model import ModifiersModel
 
 
@@ -24,6 +30,30 @@ def load_dataframe(path: str) -> pd.DataFrame:
     raise ValueError(f"unsupported format: {p.suffix}")
 
 
+def _prepare_modifier_features(features: pd.DataFrame) -> tuple[pd.DataFrame, np.ndarray]:
+    feature_cols = ["rest_days"] + sorted(
+        col for col in features.columns if col.startswith("rolling_xg_")
+    )
+
+    home = (
+        features.loc[features["is_home"] == 1, ["match_id", *feature_cols]]
+        .rename(columns={col: f"{col}_home" for col in feature_cols})
+        .copy()
+    )
+    away = (
+        features.loc[features["is_home"] == 0, ["match_id", *feature_cols]]
+        .rename(columns={col: f"{col}_away" for col in feature_cols})
+        .copy()
+    )
+
+    combined = home.merge(away, on="match_id", how="inner")
+    combined = combined.sort_values("match_id").reset_index(drop=True)
+    match_ids = combined["match_id"].to_numpy()
+    X = combined.drop(columns="match_id")
+    X.insert(0, "bias", 1.0)
+    return X, match_ids
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--season-id", required=True)
@@ -31,15 +61,20 @@ def main() -> None:
     parser.add_argument("--input", required=True)
     args = parser.parse_args()
 
-    df = load_dataframe(args.input)
-    feature_cols = [
-        c
-        for c in df.columns
-        if c not in {"lambda_home", "lambda_away", "target_home", "target_away"}
-    ]
-    X = df[feature_cols]
-    y_home = np.log(df["target_home"]) - np.log(df["lambda_home"])
-    y_away = np.log(df["target_away"]) - np.log(df["lambda_away"])
+    raw_df = load_dataframe(args.input)
+    validated = validate_input(raw_df)
+
+    required = {"lambda_home", "lambda_away", "target_home", "target_away"}
+    missing = required - set(validated.columns)
+    if missing:
+        raise ValueError(f"missing required modifier columns: {', '.join(sorted(missing))}")
+
+    features = build_features(validated)
+    X, match_ids = _prepare_modifier_features(features)
+
+    targets = validated.loc[match_ids].reset_index(drop=True)
+    y_home = np.log(targets["target_home"].astype(float)) - np.log(targets["lambda_home"].astype(float))
+    y_away = np.log(targets["target_away"].astype(float)) - np.log(targets["lambda_away"].astype(float))
     model = ModifiersModel(alpha=args.alpha).fit(X, y_home, y_away)
     out_dir = Path("artifacts") / str(args.season_id)
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/data_processor/test_features.py
+++ b/tests/data_processor/test_features.py
@@ -1,0 +1,60 @@
+"""
+@file: test_features.py
+@description: Tests for the feature engineering stage of the data processor pipeline.
+@dependencies: pandas, pytest
+@created: 2025-09-16
+
+Tests for :mod:`app.data_processor.features`.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from app.data_processor.features import build_features
+from app.data_processor.validate import validate_input
+
+
+def _make_source_df() -> pd.DataFrame:
+    dates = pd.date_range("2024-01-01", periods=6, freq="3D")
+    return pd.DataFrame(
+        {
+            "home_team": ["A", "B", "C", "A", "B", "C"],
+            "away_team": ["B", "C", "A", "C", "A", "B"],
+            "date": dates,
+            "xG_home": [1.2, 0.8, 1.5, 1.1, 0.9, 1.3],
+            "xG_away": [0.7, 1.0, 0.6, 1.2, 0.8, 0.9],
+            "goals_home": [2, 1, 3, 1, 0, 2],
+            "goals_away": [0, 2, 1, 2, 1, 1],
+        }
+    )
+
+
+def test_build_features_requires_non_empty_dataframe() -> None:
+    with pytest.raises(ValueError, match="empty dataframe"):
+        build_features(pd.DataFrame())
+
+
+def test_build_features_generates_home_and_away_rows() -> None:
+    df = validate_input(_make_source_df())
+    features = build_features(df, windows=(3, 5))
+
+    assert len(features) == len(df) * 2
+    assert set(features["is_home"].unique()) == {0, 1}
+    assert features["match_id"].nunique() == len(df)
+
+    expected_cols = {
+        "is_home",
+        "rest_days",
+        "rolling_xg_for_3",
+        "rolling_xg_against_3",
+        "rolling_xg_for_5",
+        "rolling_xg_against_5",
+    }
+    assert expected_cols.issubset(features.columns)
+
+    assert features["rest_days"].between(0, 14).all()
+    rolling = features.filter(regex=r"^rolling_xg_")
+    assert (rolling >= 0).all().all()
+    assert not rolling.isnull().any().any()

--- a/tests/data_processor/test_model_matrix.py
+++ b/tests/data_processor/test_model_matrix.py
@@ -1,0 +1,53 @@
+"""
+@file: test_model_matrix.py
+@description: Model matrix tests for the engineered features produced by the data processor.
+@dependencies: pandas, pytest
+@created: 2025-09-16
+
+Tests for :mod:`app.data_processor.matrix`.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from app.data_processor.features import build_features
+from app.data_processor.matrix import to_model_matrix
+from app.data_processor.validate import validate_input
+
+
+def _make_source_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "home_team": ["A", "B", "C", "A"],
+            "away_team": ["B", "C", "A", "C"],
+            "date": pd.date_range("2024-01-01", periods=4, freq="7D"),
+            "xG_home": [1.1, 0.9, 1.4, 1.0],
+            "xG_away": [0.6, 1.2, 0.8, 1.1],
+            "goals_home": [2, 1, 3, 0],
+            "goals_away": [0, 2, 1, 1],
+        }
+    )
+
+
+def test_to_model_matrix_requires_non_empty_dataframe() -> None:
+    with pytest.raises(ValueError, match="empty dataframe"):
+        to_model_matrix(pd.DataFrame())
+
+
+def test_to_model_matrix_produces_bias_and_targets() -> None:
+    df = validate_input(_make_source_df())
+    features = build_features(df, windows=(2,))
+    X_home, y_home, X_away, y_away = to_model_matrix(features)
+
+    assert len(X_home) == len(df)
+    assert len(X_away) == len(df)
+    assert y_home.notna().all()
+    assert y_away.notna().all()
+
+    assert "bias" in X_home.columns
+    assert "bias" in X_away.columns
+    assert all(col.startswith("rolling_xg_") or col == "rest_days" or col == "bias" for col in X_home.columns)
+    assert set(y_home.tolist()) == set(df["goals_home"].tolist())
+    assert set(y_away.tolist()) == set(df["goals_away"].tolist())

--- a/tests/data_processor/test_validate.py
+++ b/tests/data_processor/test_validate.py
@@ -1,0 +1,83 @@
+"""
+@file: test_validate.py
+@description: Validation tests for the data processor input normalisation stage.
+@dependencies: pandas, pytest
+@created: 2025-09-16
+
+Tests for :mod:`app.data_processor.validate`.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from app.data_processor.validate import validate_input
+
+
+def _make_valid_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "home_team": ["Team A", "Team B"],
+            "away_team": ["Team C", "Team A"],
+            "date": ["2024-01-01", "2024-01-05"],
+            "xG_home": [1.2, 0.9],
+            "xG_away": [0.7, 1.1],
+            "goals_home": [2, 1],
+            "goals_away": [0, 2],
+        }
+    )
+
+
+def test_validate_input_rejects_empty_dataframe() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        validate_input(pd.DataFrame())
+
+
+def test_validate_input_returns_copy_with_converted_types() -> None:
+    df = _make_valid_df()
+    validated = validate_input(df)
+
+    assert not validated.empty
+    assert validated is not df
+    assert pd.api.types.is_datetime64_any_dtype(validated["date"])
+    assert validated["home_team"].tolist() == ["Team A", "Team B"]
+    assert validated["goals_home"].dtype.kind in {"i", "u"}
+
+
+def test_validate_input_missing_column_raises() -> None:
+    df = _make_valid_df().drop(columns=["xG_home"])
+
+    with pytest.raises(ValueError, match="missing required columns"):
+        validate_input(df)
+
+
+def test_validate_input_invalid_numeric_values() -> None:
+    df = _make_valid_df()
+    df.loc[0, "xG_home"] = -0.1
+
+    with pytest.raises(ValueError, match="non-negative"):
+        validate_input(df)
+
+
+def test_validate_input_invalid_goal_type() -> None:
+    df = _make_valid_df()
+    df.loc[0, "goals_home"] = 1.5
+
+    with pytest.raises(ValueError, match="integer values"):
+        validate_input(df)
+
+
+def test_validate_input_invalid_date() -> None:
+    df = _make_valid_df()
+    df.loc[0, "date"] = "not-a-date"
+
+    with pytest.raises(ValueError, match="valid datetime"):
+        validate_input(df)
+
+
+def test_validate_input_duplicate_match_raises() -> None:
+    df = pd.concat([_make_valid_df()] * 2, ignore_index=True)
+
+    with pytest.raises(ValueError, match="duplicate match entries"):
+        validate_input(df)

--- a/tests/integration/test_pipeline_writes_markets.py
+++ b/tests/integration/test_pipeline_writes_markets.py
@@ -21,7 +21,7 @@ from services.prediction_pipeline import PredictionPipeline
 def test_pipeline_writes_markets(tmp_path, monkeypatch):
     class _Pre:
         def transform(self, df: pd.DataFrame) -> pd.DataFrame:  # noqa: D401
-            return df[[]]
+            return df
 
     monkeypatch.setenv("PREDICTIONS_DB_URL", str(tmp_path / "pred.sqlite"))
     monkeypatch.setenv("SIM_N", "512")
@@ -32,7 +32,13 @@ def test_pipeline_writes_markets(tmp_path, monkeypatch):
             "home": ["H"],
             "away": ["A"],
             "season": ["S"],
+            "home_team": ["H"],
+            "away_team": ["A"],
             "date": [pd.Timestamp("2024-01-01")],
+            "xG_home": [1.2],
+            "xG_away": [0.9],
+            "goals_home": [2],
+            "goals_away": [1],
         }
     )
 

--- a/tests/ml/test_modifiers.py
+++ b/tests/ml/test_modifiers.py
@@ -13,14 +13,16 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from app.data_processor import build_features, validate_input
 from app.ml.model_registry import LocalModelRegistry
 from ml.modifiers_model import ModifiersModel
+from scripts.train_modifiers import _prepare_modifier_features
 from services.prediction_pipeline import PredictionPipeline
 
 
 class _Pre:
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
-        return df[["x1"]]
+        return df
 
 
 class Const:
@@ -44,11 +46,17 @@ class SeasonRegistry(LocalModelRegistry):
 def test_modifiers_training_and_application(tmp_path):
     df = pd.DataFrame(
         {
-            "lambda_home": [1.0, 1.0],
-            "lambda_away": [1.0, 1.0],
+            "home_team": ["A", "B"],
+            "away_team": ["B", "A"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-08"]),
+            "xG_home": [1.1, 0.9],
+            "xG_away": [0.8, 1.2],
+            "goals_home": [2, 0],
+            "goals_away": [1, 2],
+            "lambda_home": [1.0, 1.1],
+            "lambda_away": [1.0, 0.9],
             "target_home": [1.5, 0.8],
             "target_away": [0.8, 1.5],
-            "x1": [1.0, -1.0],
         }
     )
     data_path = tmp_path / "mods.csv"
@@ -71,15 +79,18 @@ def test_modifiers_training_and_application(tmp_path):
     )
     art_dir = Path("artifacts") / str(season)
     model = ModifiersModel.load(art_dir / "modifiers_model.pkl")
+    validated = validate_input(df)
+    features = build_features(validated)
+    X_mod, _ = _prepare_modifier_features(features)
     base = np.array([1.0])
-    lam_h, lam_a = model.transform(base, base, pd.DataFrame({"x1": [10.0]}))
+    lam_h, lam_a = model.transform(base, base, X_mod.iloc[[0]])
     assert 0.7 <= lam_h[0] <= 1.4
     assert 0.7 <= lam_a[0] <= 1.4
     registry = SeasonRegistry(season)
     registry.save(Const(), "glm_home")
     registry.save(Const(), "glm_away")
     pipeline = PredictionPipeline(_Pre(), registry)
-    preds = pipeline.predict_proba(pd.DataFrame({"x1": [10.0]}))
+    preds = pipeline.predict_proba(df.iloc[[0]])
     assert preds.shape == (1, 2)
     assert 0.7 <= preds[0, 0] <= 1.4
     assert 0.7 <= preds[0, 1] <= 1.4

--- a/tests/ml/test_modifiers_metrics.py
+++ b/tests/ml/test_modifiers_metrics.py
@@ -15,7 +15,7 @@ from services.prediction_pipeline import PredictionPipeline
 def test_modifiers_metrics() -> None:
     class _Pre:
         def transform(self, df: pd.DataFrame) -> pd.DataFrame:  # type: ignore
-            return df[["x"]]
+            return df
 
     class _Model:
         def predict(self, X):  # type: ignore
@@ -35,9 +35,13 @@ def test_modifiers_metrics() -> None:
 
     df = pd.DataFrame(
         {
-            "x": [0, 1],
-            "home_goals": [1, 0],
-            "away_goals": [0, 2],
+            "home_team": ["A", "B"],
+            "away_team": ["B", "A"],
+            "date": pd.to_datetime(["2024-01-01", "2024-01-08"]),
+            "xG_home": [1.0, 0.9],
+            "xG_away": [0.8, 1.1],
+            "goals_home": [1, 0],
+            "goals_away": [0, 2],
         }
     )
     pipe = PredictionPipeline(_Pre(), _Registry())

--- a/tests/test_services_workers_minimal.py
+++ b/tests/test_services_workers_minimal.py
@@ -21,7 +21,7 @@ def test_services_prediction_pipeline_stub():
 
     class _Preproc:
         def transform(self, df: "pd.DataFrame") -> "pd.DataFrame":
-            return df.fillna(0)
+            return df
 
     class _Registry:
         class _M:
@@ -33,10 +33,20 @@ def test_services_prediction_pipeline_stub():
         def load(self, name: str, season: int | None = None):
             return self._M()
 
-    df = pd.DataFrame({"x": [1, 2, 3]})
+    df = pd.DataFrame(
+        {
+            "home_team": ["A"],
+            "away_team": ["B"],
+            "date": [pd.Timestamp("2024-01-01")],
+            "xG_home": [1.0],
+            "xG_away": [0.8],
+            "goals_home": [1],
+            "goals_away": [0],
+        }
+    )
     pipe = PredictionPipeline(preprocessor=_Preproc(), model_registry=_Registry())
     out = pipe.predict_proba(df)
-    assert getattr(out, "shape", None) == (3, 2)
+    assert getattr(out, "shape", None) == (1, 2)
 
 
 def test_workers_retrain_scheduler_register_called(monkeypatch):


### PR DESCRIPTION
## Summary
- implement full validation, feature engineering, and model matrix generation in the data processor package
- wire the new data processor into GLM and modifiers training scripts and the services prediction pipeline
- refresh ML and pipeline tests plus documentation to match the new feature set

## Testing
- pytest -q tests/data_processor/test_validate.py tests/data_processor/test_features.py tests/data_processor/test_model_matrix.py
- pytest -q -k "glm_training or modifiers"
- pytest -q -k "prediction_pipeline"


------
https://chatgpt.com/codex/tasks/task_e_68c8f06f8598832e90c42f72cc03e6b3