### PR TITLE
Normalize recommendation engine and worker invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## [2025-09-20] - E4: Recommendation engine invariants
+### Added
+- Normalised `RecommendationEngine.generate_prediction` payload and predictor facade in `core/services`.
+- Dependency-injected worker with Redis locks and queue status reporting.
+- Test suites covering probability invariants and worker behaviour.
+
+### Changed
+- README and docs updated with ML invariants and new architecture notes.
+
+### Fixed
+- Removed invalid awaits and global clients in prediction worker, resolving audit findings.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ python scripts/run_simulation.py --season-id default --home H --away A --rho 0.1
     --n-sims 10000 --calibrate --write-db --report-md reports/metrics/ECE_simulation_default_H_vs_A.md
 ```
 
+## ML-ядро и инварианты
+
+- `RecommendationEngine` получает данные через `DBRouter` и нормализует выходные словари перед возвратом (`1X2`, Totals, BTTS).
+- Прогнозы симулируются детерминированно: `seed` берётся из настроек (`SIM_SEED`) и прокидывается через сервис предсказаний.
+- Перед возвратом фильтруются `NaN`/отрицательные вероятности, `scoreline_topk` сортируется по убыванию.
+- При сбоях воркер фиксирует статусы `queued/start/finished/failed`, что совместимо с `TaskManager` и внешним мониторингом.
+
 ## Storage
 
 Predictions are stored via SQLite fallback (`storage/persistence.py`).

--- a/config.py
+++ b/config.py
@@ -89,6 +89,11 @@ class Settings(BaseSettings):
     SIM_RHO: float = 0.1
     SIM_N: int = 10000
     SIM_CHUNK: int = 100000
+    SIM_SEED: int = 20240920
+
+    # --- Worker coordination ---
+    PREDICTION_LOCK_TIMEOUT: float = 60.0
+    PREDICTION_LOCK_BLOCKING_TIMEOUT: float = 5.0
 
     # --- Динамические поля ---
     @computed_field  # Генерируется на основе других полей

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,8 @@
+"""
+@file: core/__init__.py
+@description: Core package exposing service-level abstractions.
+@dependencies: None
+@created: 2025-09-20
+"""
+
+__all__ = []

--- a/core/services/__init__.py
+++ b/core/services/__init__.py
@@ -1,0 +1,10 @@
+"""
+@file: core/services/__init__.py
+@description: Export surface for core service implementations.
+@dependencies: None
+@created: 2025-09-20
+"""
+
+from .predictor import PredictorService
+
+__all__ = ["PredictorService"]

--- a/core/services/predictor.py
+++ b/core/services/predictor.py
@@ -1,0 +1,66 @@
+"""
+@file: core/services/predictor.py
+@description: Predictor service orchestrating recommendation engine payload normalisation.
+@dependencies: services.recommendation_engine.RecommendationEngine
+@created: 2025-09-20
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from services.recommendation_engine import (
+    InvalidPredictionRequest,
+    PredictionEngineError,
+    RecommendationEngine,
+)
+
+
+class PredictorServiceError(RuntimeError):
+    """Raised when predictor service fails to generate a payload."""
+
+
+class PredictorService:
+    """Wrapper around :class:`RecommendationEngine` exposing a stable interface."""
+
+    def __init__(self, engine: RecommendationEngine) -> None:
+        self._engine = engine
+
+    async def generate_prediction(
+        self,
+        fixture_id: str | None = None,
+        *,
+        home: str | None = None,
+        away: str | None = None,
+        seed: int,
+        n_sims: int,
+    ) -> dict[str, Any]:
+        try:
+            prediction = await self._engine.generate_prediction(
+                fixture_id,
+                home=home,
+                away=away,
+                seed=seed,
+                n_sims=n_sims,
+            )
+        except (InvalidPredictionRequest, PredictionEngineError) as exc:
+            raise PredictorServiceError(str(exc)) from exc
+
+        totals = prediction["totals"]
+        return {
+            "fixture_id": prediction.get("fixture_id"),
+            "league": prediction.get("league"),
+            "utc_kickoff": prediction.get("utc_kickoff"),
+            "teams": deepcopy(prediction.get("teams", {})),
+            "expected_goals": deepcopy(prediction.get("expected_goals", {})),
+            "seed": prediction.get("seed"),
+            "n_sims": prediction.get("n_sims"),
+            "probs": dict(prediction.get("probs", {})),
+            "totals": {
+                "over_2_5": totals.get("over_2_5"),
+                "under_2_5": totals.get("under_2_5"),
+                "btts_yes": totals.get("btts_yes"),
+                "btts_no": totals.get("btts_no"),
+            },
+            "scoreline_topk": list(prediction.get("scoreline_topk", [])),
+        }

--- a/docs/Project.md
+++ b/docs/Project.md
@@ -27,6 +27,8 @@ telegram-bot/
 ├─ config.py                 | настройки, MODEL_VERSION, env
 ├─ logger.py                 | логирование (Loguru JSON + Sentry)
 ├─ observability.py          | инициализация Sentry и Prometheus
+├─ core/
+│  └─ services/predictor.py      # фасад RecommendationEngine с унифицированным payload
 ├─ app/
 │  ├─ integrations/
 │  │  └─ sportmonks_client.py     # STUB-aware SportMonks API client
@@ -90,6 +92,8 @@ telegram-bot/
 Калибровка: Platt/Isotonic; online-контроль ECE/LogLoss.
 Рынки: 1X2, Totals (2.5 + расширение), BTTS, точные счёта (топ-N).
 Value: `fair_odds = 1/p`; сравнение с внешними котировками (если подключено).
+`RecommendationEngine` нормализует словари 1X2/Totals/BTTS, отбрасывает «грязные» вероятности и сортирует top-k; генерация
+детерминирована seed-ом из настроек (`SIM_SEED`).
 
 ## 5. Данные и хранилища
 **Охват данных:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,13 @@
+## [2025-09-20] - E4: Recommendation engine invariants
+### Добавлено
+- Унифицированный `RecommendationEngine.generate_prediction` с нормализацией 1X2/Totals/BTTS и top-k счётов.
+- Сервис `core/services/predictor.py` и DI-воркер с поддержкой статусов и Redis-lock.
+- Тесты `tests/ml/test_prediction_invariants.py` и `tests/workers/test_prediction_worker.py` для проверки инвариантов и очереди.
+### Изменено
+- README получил раздел «ML-ядро и инварианты», Project.md описывает новый фасад и детерминированный seed.
+### Исправлено
+- Исключены `await` синхронных методов и глобальные клиенты в worker; ошибки audit.md по несуществующим API устранены.
+
 ## [2025-09-19] - E3: Telegram UX overhaul
 ### Добавлено
 - Ди-инжектируемые обработчики `/help`, `/model`, `/today`, `/match`, `/predict` с новым модулем форматирования `telegram/widgets.py`.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,13 @@
+## Задача: E4 — Recommendation engine invariants
+- **Статус**: Завершена
+- **Описание**: Нормализовать интерфейсы RecommendationEngine/PredictorService/воркера и гарантировать инварианты вероятностей.
+- **Шаги выполнения**:
+  - [x] Переписан `services/recommendation_engine` и добавлен фасад `core/services/predictor.py`.
+  - [x] Обновлён `workers/prediction_worker.py` на DI с Redis-lock и статусами очереди.
+  - [x] Добавлены тесты `tests/ml/test_prediction_invariants.py` и `tests/workers/test_prediction_worker.py`.
+  - [x] README, Project.md и changelog отражают новые инварианты.
+- **Зависимости**: services/recommendation_engine.py, core/services/predictor.py, workers/prediction_worker.py, tests/ml/test_prediction_invariants.py, tests/workers/test_prediction_worker.py, README.md, docs/Project.md, docs/changelog.md
+
 ## Задача: E3 — Telegram UX и форматирование
 - **Статус**: Завершена
 - **Описание**: Обновить команды Telegram-бота, привести обработчики к DI, добавить форматирование ответов и smoke-тесты.

--- a/services/prediction_pipeline.py
+++ b/services/prediction_pipeline.py
@@ -14,8 +14,8 @@ try:  # optional import for constrained environments
 except Exception:  # pragma: no cover
     pd = Any  # type: ignore
 
-from app.data_processor import build_features, to_model_matrix, validate_input
 from app.config import get_settings
+from app.data_processor import build_features, to_model_matrix, validate_input
 from logger import logger
 from metrics import ece_poisson, logloss_poisson, record_metrics
 

--- a/services/recommendation_engine.py
+++ b/services/recommendation_engine.py
@@ -1,589 +1,407 @@
-# services/recommendation_engine.py
-"""Сервис для генерации комплексных прогнозов и рекомендаций."""
-# (cleanup) удалены неиспользуемые импорты asyncio и timedelta
+"""
+@file: services/recommendation_engine.py
+@description: Deterministic Monte-Carlo based recommendation engine with DB-backed
+    inputs and probability invariants.
+@dependencies: numpy, sqlalchemy, database.db_router.DBRouter, logger
+@created: 2025-09-20
+"""
+from __future__ import annotations
+
+import math
+from collections import Counter
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from datetime import datetime
-from enum import Enum
+from datetime import UTC, datetime
 from typing import Any
 
-from config import CONFIDENCE, get_settings
+import numpy as np
+from sqlalchemy import text
+
+from database import DBRouter
 from logger import logger
 
-# Импорт моделей
-from ml.models.poisson_model import poisson_model
-from ml.models.poisson_regression_model import poisson_regression_model
-
-# Импорт нового модуля Bivariate Poisson
-try:
-    from ml.models.bivariate_poisson import BivariatePoisson, estimate_rho
-
-    HAS_BIVARIATE_POISSON = True
-except ImportError:
-    HAS_BIVARIATE_POISSON = False
-    logger.warning("Bivariate Poisson модель не доступна")
-# Импорт сервисов
-from ml.base_poisson_glm import BasePoissonModel, base_poisson_model
-from ml.calibration import ProbabilityCalibrator
-from ml.modifiers_model import prediction_modifier
-from services.data_processor import data_processor
-from services.sportmonks_client import sportmonks_client
-
-# Импорт модуля логирования в БД
-try:
-    from database.db_logging import log_prediction  # async
-except Exception:  # pragma: no cover
-    log_prediction = None
+_PROB_TOLERANCE = 1e-6
+_DEFAULT_SCORELINE_TOPK = 6
+_MIN_PROBABILITY = 1e-9
 
 
-def _calc_missing_ratio(team_stats: dict[str, Any]) -> float:
-    """
-    Оцениваем долю пропусков по ключевым фичам с обеих сторон.
-    Ожидаем структуру: {'home': {...}, 'away': {...}}.
-    """
-    try:
-        home = (team_stats or {}).get("home", {}) or {}
-        away = (team_stats or {}).get("away", {}) or {}
-        keys = ["xg", "shots", "ppda", "passes", "pass_accuracy"]
-        vals = [home.get(k) for k in keys] + [away.get(k) for k in keys]
-        miss = sum(1 for v in vals if v is None)
-        return miss / max(1, len(vals))
-    except Exception:
-        return 0.0
+class PredictionEngineError(RuntimeError):
+    """Base class for recommendation engine errors."""
 
 
-class RiskLevel(Enum):
-    """Уровень риска ставки."""
-
-    LOW = "низкий"
-    MEDIUM = "средний"
-    HIGH = "высокий"
+class InvalidPredictionRequest(PredictionEngineError):
+    """Raised when request payload misses mandatory identifiers."""
 
 
-@dataclass
-class BettingRecommendation:
-    """Рекомендация по ставке."""
+class FixtureNotFoundError(PredictionEngineError):
+    """Raised when fixture metadata cannot be located in the database."""
 
-    market: str
-    selection: str
-    confidence: float
-    risk_level: RiskLevel
-    reasoning: str
+
+class MetricsNotFoundError(PredictionEngineError):
+    """Raised when team metrics required for simulation are unavailable."""
+
+
+@dataclass(slots=True)
+class FixtureRecord:
+    """Simple representation of fixture metadata fetched from the database."""
+
+    fixture_id: int
+    home_team: str
+    away_team: str
+    league: str | None
+    kickoff: datetime | None
+    home_team_id: int | None
+    away_team_id: int | None
+
+
+@dataclass(slots=True)
+class TeamMetrics:
+    """Aggregated metrics for a team used to derive Poisson intensities."""
+
+    team_id: int | None
+    name: str
+    attack_strength: float | None
+    defence_strength: float | None
+    lambda_for: float | None
+    lambda_against: float | None
+    xg_for: float | None
+    xg_against: float | None
+
+    def candidates_for_scoring(self) -> Iterable[float]:
+        yield from _finite_positive(
+            (
+                self.lambda_for,
+                self.xg_for,
+                self.attack_strength,
+            )
+        )
+
+    def candidates_for_conceding(self) -> Iterable[float]:
+        yield from _finite_positive(
+            (
+                self.lambda_against,
+                self.xg_against,
+                self.defence_strength,
+            )
+        )
+
+
+def _finite_positive(values: Iterable[float | None]) -> list[float]:
+    cleaned: list[float] = []
+    for value in values:
+        if value is None:
+            continue
+        try:
+            as_float = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isnan(as_float) or math.isinf(as_float) or as_float <= 0:
+            continue
+        cleaned.append(as_float)
+    return cleaned
+
+
+def _normalize_pair(a: float, b: float) -> tuple[float, float]:
+    first = max(_MIN_PROBABILITY, max(0.0, a))
+    second = max(_MIN_PROBABILITY, max(0.0, b))
+    total = first + second
+    if total <= 0:
+        return 0.5, 0.5
+    return first / total, second / total
+
+
+def _normalize_triplet(values: Mapping[str, float]) -> dict[str, float]:
+    cleaned = {key: max(_MIN_PROBABILITY, max(0.0, float(value))) for key, value in values.items()}
+    total = sum(cleaned.values())
+    if total <= 0:
+        uniform = 1.0 / max(1, len(cleaned))
+        return {key: uniform for key in cleaned}
+    return {key: value / total for key, value in cleaned.items()}
 
 
 class RecommendationEngine:
-    """Движок для генерации рекомендаций."""
+    """Main entry point responsible for generating prediction payloads."""
 
-    def __init__(self, sportmonks_client, base_model: BasePoissonModel | None = None):
-        """Инициализация Recommendation Engine."""
-        self.settings = get_settings()
-        self.poisson_model = poisson_model
-        self.regression_model = poisson_regression_model
-        self.base_model = base_model or base_poisson_model
-        # Инициализация сервисов
-        self.data_processor = data_processor
-        self.modifier = prediction_modifier
-        self.home_advantage_factor = 1.15  # Базовое преимущество домашней команды
-        # Инициализация клиента
-        self.sportmonks_client = sportmonks_client
-        # Инициализация калибратора вероятностей для 1X2
-        try:
-            self.calibrator = ProbabilityCalibrator(
-                keys=["home_win", "draw", "away_win"],
-                weights={"draw": 0.7},  # пример: чуть мягче калибровать ничью
-                strict_guard=True,
-                max_shift=0.25,
-                max_weight_on_large_shift=0.5,
-            )
-        except Exception:
-            # не блокируем работу движка, если калибратор недоступен
-            self.calibrator = None
-        logger.info("RecommendationEngine инициализирован")
+    def __init__(
+        self,
+        db_router: DBRouter,
+        *,
+        fixtures_table: str = "fixtures",
+        metrics_table: str = "team_metrics",
+        scoreline_topk: int = _DEFAULT_SCORELINE_TOPK,
+    ) -> None:
+        self._db_router = db_router
+        self._fixtures_table = fixtures_table
+        self._metrics_table = metrics_table
+        self._scoreline_topk = scoreline_topk
 
-    @staticmethod
-    def _confidence_from_probs(probs: dict[str, float]) -> float:
-        """
-        Универсальный расчёт confidence:
-        - 3-исход: margin(top1 - top2) для {home_win,draw,away_win} или probability_*.
-        - 2-исход: |p1 - p2| для {yes,no} или {over,under} или {p1,p2}.
-        """
-        keys = set(probs.keys())
-        # 3-way
-        if {"home_win", "draw", "away_win"}.issubset(keys) or {
-            "probability_home_win",
-            "probability_draw",
-            "probability_away_win",
-        }.issubset(keys):
-            h = float(probs.get("home_win", probs.get("probability_home_win", 0.0)))
-            d = float(probs.get("draw", probs.get("probability_draw", 0.0)))
-            a = float(probs.get("away_win", probs.get("probability_away_win", 0.0)))
-            vals = sorted([h, d, a], reverse=True)
-            return float(max(0.0, min(1.0, (vals[0] - vals[1]) if len(vals) >= 2 else 0.0)))
-        # 2-way
-        if {"yes", "no"}.issubset(keys):
-            p1, p2 = float(probs["yes"]), float(probs["no"])
-            return float(max(0.0, min(1.0, abs(p1 - p2))))
-        if {"over", "under"}.issubset(keys):
-            p1, p2 = float(probs["over"]), float(probs["under"])
-            return float(max(0.0, min(1.0, abs(p1 - p2))))
-        if {"p1", "p2"}.issubset(keys):
-            p1, p2 = float(probs["p1"]), float(probs["p2"])
-            return float(max(0.0, min(1.0, abs(p1 - p2))))
-        # fallback
-        try:
-            vals = sorted([float(v) for v in probs.values()], reverse=True)
-            return float(max(0.0, min(1.0, (vals[0] - vals[1]) if len(vals) >= 2 else 0.0)))
-        except Exception:
-            return 0.0
+    async def generate_prediction(
+        self,
+        fixture_id: str | None = None,
+        *,
+        home: str | None = None,
+        away: str | None = None,
+        seed: int,
+        n_sims: int,
+    ) -> dict[str, Any]:
+        if n_sims <= 0:
+            raise InvalidPredictionRequest("n_sims must be positive")
 
-    def compute_confidence_from_margin(self, probs: dict[str, float]) -> float:
-        """Совместимый интерфейс для расчёта confidence по словарю вероятностей."""
-        return self._confidence_from_probs(probs)
-
-    @staticmethod
-    def _penalize_confidence(
-        base: float, *, missing_ratio: float = 0.0, freshness_minutes: float = 0.0
-    ) -> float:
-        """Применяем штрафы за пропуски и устаревшие данные."""
-        try:
-            c = float(base)
-            c *= 1 - float(CONFIDENCE.get("missing_penalty_alpha", 0.2)) * float(missing_ratio)
-            freshness_penalty = float(CONFIDENCE.get("freshness_penalty_alpha", 0.15)) * (
-                float(freshness_minutes) / 60.0
-            )
-            c *= max(0.0, 1 - freshness_penalty)
-            return float(max(0.0, min(1.0, c)))
-        except Exception:
-            return base
-
-    def penalize_confidence(
-        self, base: float, *, missing_ratio: float = 0.0, freshness_minutes: float = 0.0
-    ) -> float:
-        """Публичный интерфейс для штрафов уверенности."""
-        return self._penalize_confidence(
-            base, missing_ratio=missing_ratio, freshness_minutes=freshness_minutes
+        fixture = await self._resolve_fixture(fixture_id, home, away)
+        home_metrics = await self._load_team_metrics(
+            fixture.home_team_id, fixture.home_team
+        )
+        away_metrics = await self._load_team_metrics(
+            fixture.away_team_id, fixture.away_team
         )
 
-    async def generate_comprehensive_prediction(self, match_data: dict[str, Any]) -> dict[str, Any]:
-        """Генерация комплексного прогноза."""
+        lambda_home, lambda_away = self._estimate_lambdas(home_metrics, away_metrics)
+        logger.debug(
+            "simulation_inputs fixture=%s λH=%.3f λA=%.3f seed=%s n_sims=%s",
+            fixture.fixture_id,
+            lambda_home,
+            lambda_away,
+            seed,
+            n_sims,
+        )
+
+        simulation = self._simulate(lambda_home, lambda_away, seed=seed, n_sims=n_sims)
+        self._assert_invariants(simulation)
+
+        payload = {
+            "fixture_id": fixture.fixture_id,
+            "league": fixture.league,
+            "utc_kickoff": fixture.kickoff.isoformat() if fixture.kickoff else None,
+            "teams": {
+                "home": fixture.home_team,
+                "away": fixture.away_team,
+            },
+            "expected_goals": {
+                "home": lambda_home,
+                "away": lambda_away,
+            },
+            "seed": seed,
+            "n_sims": n_sims,
+            "probs": simulation["probs"],
+            "totals": simulation["totals"],
+            "scoreline_topk": simulation["scoreline_topk"],
+        }
+        return payload
+
+    async def _resolve_fixture(
+        self,
+        fixture_id: str | None,
+        home: str | None,
+        away: str | None,
+    ) -> FixtureRecord:
+        if fixture_id is None and (home is None or away is None):
+            raise InvalidPredictionRequest(
+                "Either fixture_id or both home and away teams must be provided"
+            )
+
+        if fixture_id is None:
+            return FixtureRecord(
+                fixture_id=0,
+                home_team=home or "home",
+                away_team=away or "away",
+                league=None,
+                kickoff=None,
+                home_team_id=None,
+                away_team_id=None,
+            )
+
         try:
-            logger.info(
-                f"Генерация комплексного прогноза для матча "
-                f"{match_data.get('home_team', 'Unknown')} - "
-                f"{match_data.get('away_team', 'Unknown')}"
-            )
-            # Проверяем, устарела ли модель регрессии
-            if self.regression_model.is_model_outdated():
-                logger.warning(
-                    "⚠️ Модель регрессии устарела. Прогноз может быть менее точным. "
-                    "Рекомендуется запустить переобучение модели."
-                )
-            team_stats = match_data.get("team_stats", {})
-            # 1. Расчет базовых λ
-            base_lambdas = await self.base_model.estimate(match_data, team_stats)
-            # 2. Подготовка контекста матча
-            match_context = await self._prepare_match_context(match_data, team_stats)
-            # 3. Применение модификаторов
-            modified_lambdas = await self.modifier.apply_dynamic_modifiers(
-                base_lambdas[0], base_lambdas[1], match_context
-            )
-            # 4. Прогнозирование с использованием Poisson модели
-            poisson_input = {
-                "home_stats": match_data.get("home_stats", {}),
-                "away_stats": match_data.get("away_stats", {}),
-                "home_team": {"team_name": match_data.get("home_team")},
-                "away_team": {"team_name": match_data.get("away_team")},
-            }
-            poisson_result = self.poisson_model.predict(poisson_input)
-            # ⚙️ Калибруем 1X2 вероятности, если калибратор доступен
-            if hasattr(self, "calibrator") and self.calibrator is not None:
-                try:
-                    # Поддерживаем оба набора ключей: probability_* или home/draw/away
-                    to_calibrate = {
-                        "home_win": float(
-                            poisson_result.get(
-                                "home_win",
-                                poisson_result.get("probability_home_win", 0.0),
-                            )
-                        ),
-                        "draw": float(
-                            poisson_result.get("draw", poisson_result.get("probability_draw", 0.0))
-                        ),
-                        "away_win": float(
-                            poisson_result.get(
-                                "away_win",
-                                poisson_result.get("probability_away_win", 0.0),
-                            )
-                        ),
-                    }
-                    calibrated_1x2 = self.calibrator.predict(to_calibrate)
-                    # возвращаем в исходный нейминг, которым далее пользуется код
-                    poisson_result.update(
-                        {
-                            "home_win": calibrated_1x2.get("home_win", to_calibrate["home_win"]),
-                            "draw": calibrated_1x2.get("draw", to_calibrate["draw"]),
-                            "away_win": calibrated_1x2.get("away_win", to_calibrate["away_win"]),
-                            "probability_home_win": calibrated_1x2.get(
-                                "home_win", to_calibrate["home_win"]
-                            ),
-                            "probability_draw": calibrated_1x2.get("draw", to_calibrate["draw"]),
-                            "probability_away_win": calibrated_1x2.get(
-                                "away_win", to_calibrate["away_win"]
-                            ),
-                        }
-                    )
-                except Exception as _e:
-                    logger.warning("Calibrator skipped: %s", _e)
-            # 5. Подготовка информации о пропущенных данных
-            missing_ratio = _calc_missing_ratio(team_stats)
-            missing_data_info = {
-                "missing_ratio": missing_ratio,
-                "data_freshness_minutes": 0.0,  # В реальной реализации здесь будет расчет свежести данных
-            }
-            # 6. Генерация рекомендаций с учетом пропущенных данных
-            recommendations = await self._generate_betting_recommendations(
-                modified_lambdas[0],
-                modified_lambdas[1],
-                poisson_result,
-                match_context,
-                missing_data_info,
-            )
-            # === Confidence: margin + penalties ===
-            try:
-                base_conf = self._confidence_from_probs(poisson_result)
-                confidence = self._penalize_confidence(
-                    base_conf,
-                    missing_ratio=missing_ratio,
-                    freshness_minutes=missing_data_info.get("data_freshness_minutes", 0.0),
-                )
-            except Exception as _e:
-                logger.warning("Ошибка при расчёте confidence: %s", _e)
-                confidence = 0.0
-            # 7. Агрегация результатов
-            detailed_prediction = {
-                "model": "ThreeLevelPoisson",
-                "expected_goals": {
-                    "home": round(modified_lambdas[0], 3),
-                    "away": round(modified_lambdas[1], 3),
-                },
-                "probabilities": poisson_result,
-                "best_recommendation": (
-                    recommendations[0].market + ": " + recommendations[0].selection
-                    if recommendations
-                    else "Ставки не определены"
-                ),
-                "confidence": round(confidence, 3),
-                "risk_level": recommendations[0].risk_level.value if recommendations else "высокий",
-                "recommendations_count": len(recommendations),
-                "generated_at": datetime.now().isoformat(),
-                "missing_data_info": missing_data_info,
-                "model_name": "poisson",
-                "model_version": self.settings.MODEL_VERSION,
-                "cache_version": getattr(self.settings, "CACHE_VERSION", None),
-                "model_flags": getattr(self.settings, "MODEL_FLAGS", None),
-            }
-            # где-то выше у тебя есть результат Пуассона (poisson_result) с λ
-            # например: {"lambda_home": ..., "lambda_away": ..., ...}
-            try:
-                lambda_home = float(poisson_result.get("lambda_home", 0.0))
-                lambda_away = float(poisson_result.get("lambda_away", 0.0))
-            except Exception:
-                lambda_home, lambda_away = 0.0, 0.0
-            expected_total = float(lambda_home + lambda_away)
+            fixture_int = int(fixture_id)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - validation guard
+            raise InvalidPredictionRequest("fixture_id must be numeric") from exc
 
-            # Добавляем ожидаемый тотал в детальный ответ, чтобы он попал в БД (в JSON-мету)
-            # В таблице predictions также есть STORED-колонка expected_total (λh+λa), но хранить значение
-            # в detailed_prediction удобно для внешних интеграций/логов.
-            detailed_prediction["expected_total"] = expected_total
-            # === Async DB log (best-effort) ===
+        query = text(
+            f"""
+            SELECT id, home_team, away_team, league, utc_kickoff, home_team_id, away_team_id
+            FROM {self._fixtures_table}
+            WHERE id = :fixture_id
+            LIMIT 1
+            """
+        )
+        async with self._db_router.session(read_only=True) as session:
+            result = await session.execute(query, {"fixture_id": fixture_int})
+            row = result.one_or_none()
+
+        if row is None:
+            raise FixtureNotFoundError(f"Fixture {fixture_id} not found")
+
+        kickoff = row.utc_kickoff
+        if isinstance(kickoff, str):
             try:
-                if log_prediction is not None:
-                    match_id = (
-                        match_data.get("id")
-                        or match_data.get("fixture_id")
-                        or match_data.get("match_id")
-                        or 0
-                    )
-                    await log_prediction(
-                        match_id=int(match_id),
-                        features={"context": match_context},
-                        probs=poisson_result,
-                        lam_home=float(modified_lambdas[0]),
-                        lam_away=float(modified_lambdas[1]),
-                        confidence=float(confidence),
-                        model_name="poisson",
-                        model_version=self.settings.MODEL_VERSION,
-                        cache_version=getattr(self.settings, "CACHE_VERSION", None),
-                        model_flags=getattr(self.settings, "MODEL_FLAGS", None),
-                    )
-            except Exception as _e:
-                logger.warning("Логирование прогноза не выполнено: %s", _e)
-            logger.info("Комплексный прогноз сгенерирован")
-            return detailed_prediction
-        except Exception as e:
-            logger.error(f"Ошибка при генерации комплексного прогноза: {e}", exc_info=True)
-            return {
-                "model": "ThreeLevelPoisson",
-                "error": str(e),
-                "expected_goals": {"home": 0, "away": 0},
-                "probabilities": {},
-                "best_recommendation": "Ставки не определены",
-                "confidence": 0.0,
-                "risk_level": "высокий",
-                "recommendations_count": 0,
-                "missing_data_info": {
-                    "missing_ratio": 0.0,
-                    "data_freshness_minutes": 0.0,
-                },
-            }
+                kickoff = datetime.fromisoformat(kickoff.replace("Z", "+00:00"))
+            except ValueError:
+                kickoff = None
+        if isinstance(kickoff, datetime) and kickoff.tzinfo is None:
+            kickoff = kickoff.replace(tzinfo=UTC)
 
-    async def _prepare_match_context(self, match_data: dict, team_stats: dict) -> dict[str, Any]:
-        """Подготовка контекста матча."""
-        try:
-            # В реальной реализации здесь будет подготовка контекста
-            context = {
-                "importance_factor": 1.0,
-                "home_team_fatigue": 0,
-                "away_team_fatigue": 0,
-                "tactical_advantage": 0.0,
-                "weather_and_pitch": {},
-                "match_importance": 0.5,
-                "style_mismatch": 0.0,
-                "missing_ratio": 0.0,  # Пример
-            }
-            return context
-        except Exception as e:
-            logger.error(f"Ошибка при подготовке контекста матча: {e}")
-            return {}
+        return FixtureRecord(
+            fixture_id=int(row.id),
+            home_team=str(row.home_team),
+            away_team=str(row.away_team),
+            league=str(row.league) if row.league is not None else None,
+            kickoff=kickoff,
+            home_team_id=row.home_team_id,
+            away_team_id=row.away_team_id,
+        )
 
-    async def _generate_betting_recommendations(
+    async def _load_team_metrics(
+        self,
+        team_id: int | None,
+        team_name: str,
+    ) -> TeamMetrics:
+        params: dict[str, Any]
+        if team_id is not None:
+            query = text(
+                f"""
+                SELECT team_id, team_name, attack_strength, defence_strength,
+                       lambda_for, lambda_against, xg_for, xg_against
+                FROM {self._metrics_table}
+                WHERE team_id = :team_id
+                LIMIT 1
+                """
+            )
+            params = {"team_id": int(team_id)}
+        else:
+            query = text(
+                f"""
+                SELECT team_id, team_name, attack_strength, defence_strength,
+                       lambda_for, lambda_against, xg_for, xg_against
+                FROM {self._metrics_table}
+                WHERE LOWER(team_name) = LOWER(:team_name)
+                LIMIT 1
+                """
+            )
+            params = {"team_name": team_name}
+
+        async with self._db_router.session(read_only=True) as session:
+            result = await session.execute(query, params)
+            row = result.one_or_none()
+
+        if row is None:
+            identifier = team_id if team_id is not None else team_name
+            raise MetricsNotFoundError(f"Metrics missing for team {identifier}")
+
+        return TeamMetrics(
+            team_id=row.team_id,
+            name=row.team_name,
+            attack_strength=row.attack_strength,
+            defence_strength=row.defence_strength,
+            lambda_for=row.lambda_for,
+            lambda_against=row.lambda_against,
+            xg_for=row.xg_for,
+            xg_against=row.xg_against,
+        )
+
+    def _estimate_lambdas(
+        self,
+        home: TeamMetrics,
+        away: TeamMetrics,
+    ) -> tuple[float, float]:
+        home_candidates = list(home.candidates_for_scoring()) + list(
+            away.candidates_for_conceding()
+        )
+        away_candidates = list(away.candidates_for_scoring()) + list(
+            home.candidates_for_conceding()
+        )
+
+        lambda_home = self._aggregate_lambda(home_candidates)
+        lambda_away = self._aggregate_lambda(away_candidates)
+        return lambda_home, lambda_away
+
+    @staticmethod
+    def _aggregate_lambda(candidates: Iterable[float]) -> float:
+        values = [value for value in candidates if value > 0]
+        if not values:
+            return 1.2
+        # Geometric mean is robust for multiplicative strengths
+        log_sum = sum(math.log(value) for value in values)
+        mean = math.exp(log_sum / len(values))
+        return max(0.05, float(mean))
+
+    def _simulate(
         self,
         lambda_home: float,
         lambda_away: float,
-        probabilities: dict[str, float],
-        match_context: dict[str, Any],
-        missing_data_info: dict[str, Any] | None = None,
-    ) -> list[BettingRecommendation]:
-        """Генерация рекомендаций по ставкам."""
-        try:
-            logger.debug("Генерация рекомендаций по ставкам")
-            recommendations: list[BettingRecommendation] = []
-            missing_ratio = (missing_data_info or {}).get("missing_ratio", 0.0)
-            data_freshness_minutes = (missing_data_info or {}).get("data_freshness_minutes", 0.0)
-            # === Result market ===
-            home_prob = float(
-                probabilities.get("probability_home_win", probabilities.get("home_win", 0.0))
-            )
-            draw_prob = float(probabilities.get("probability_draw", probabilities.get("draw", 0.0)))
-            away_prob = float(
-                probabilities.get("probability_away_win", probabilities.get("away_win", 0.0))
-            )
-            result_confidence = self._confidence_from_probs(
-                {
-                    "probability_home_win": home_prob,
-                    "probability_draw": draw_prob,
-                    "probability_away_win": away_prob,
-                }
-            )
-            res_risk = (
-                RiskLevel.HIGH
-                if result_confidence < 0.15
-                else RiskLevel.MEDIUM
-                if result_confidence < 0.3
-                else RiskLevel.LOW
-            )
-            if home_prob > 0.5:
-                rec = BettingRecommendation(
-                    market="1X2",
-                    selection="Home",
-                    confidence=result_confidence,
-                    risk_level=res_risk,
-                    reasoning="Высокая вероятность победы домашней команды",
-                )
-                penalized_confidence = self._penalize_confidence(
-                    rec.confidence,  # base
-                    missing_ratio=missing_ratio,
-                    freshness_minutes=data_freshness_minutes,
-                )
-                rec.confidence = penalized_confidence
-                recommendations.append(rec)
-            if draw_prob > 0.5:
-                rec = BettingRecommendation(
-                    market="1X2",
-                    selection="Draw",
-                    confidence=result_confidence,
-                    risk_level=RiskLevel.HIGH,
-                    reasoning="Высокая вероятность ничьей",
-                )
-                penalized_confidence = self._penalize_confidence(
-                    rec.confidence,  # base
-                    missing_ratio=missing_ratio,
-                    freshness_minutes=data_freshness_minutes,
-                )
-                rec.confidence = penalized_confidence
-                recommendations.append(rec)
-            if away_prob > 0.5:
-                rec = BettingRecommendation(
-                    market="1X2",
-                    selection="Away",
-                    confidence=result_confidence,
-                    risk_level=res_risk,
-                    reasoning="Высокая вероятность победы гостевой команды",
-                )
-                penalized_confidence = self._penalize_confidence(
-                    rec.confidence,  # base
-                    missing_ratio=missing_ratio,
-                    freshness_minutes=data_freshness_minutes,
-                )
-                rec.confidence = penalized_confidence
-                recommendations.append(rec)
-            # === Totals & BTTS markets ===
-            over_prob = float(
-                probabilities.get("probability_over_2_5", probabilities.get("over", 0.0))
-            )
-            under_prob = float(
-                probabilities.get("probability_under_2_5", probabilities.get("under", 0.0))
-            )
-            total_corr_probs = {"over": over_prob, "under": under_prob}
-            total_confidence = self._confidence_from_probs(total_corr_probs)
-            tot_risk = (
-                RiskLevel.HIGH
-                if total_confidence < 0.1
-                else RiskLevel.MEDIUM
-                if total_confidence < 0.25
-                else RiskLevel.LOW
-            )
-            btts_yes_prob = float(
-                probabilities.get("probability_btts_yes", probabilities.get("yes", 0.0))
-            )
-            btts_no_prob = float(
-                probabilities.get("probability_btts_no", probabilities.get("no", 0.0))
-            )
-            btts_corr_probs = {"yes": btts_yes_prob, "no": btts_no_prob}
-            btts_confidence = self._confidence_from_probs(btts_corr_probs)
-            btts_risk = (
-                RiskLevel.HIGH
-                if btts_confidence < 0.1
-                else RiskLevel.MEDIUM
-                if btts_confidence < 0.25
-                else RiskLevel.LOW
-            )
-            # оцениваем рекомендации на основе скорректированных вероятностей
-            if total_confidence > 0.5:
-                selection = "Over" if over_prob > under_prob else "Under"
-                reasoning = (
-                    "Высокая вероятность тотала больше 2.5"
-                    if selection == "Over"
-                    else "Высокая вероятность тотала меньше 2.5"
-                )
-                rec = BettingRecommendation(
-                    market="Totals",
-                    selection=selection,
-                    confidence=total_confidence,
-                    risk_level=tot_risk,
-                    reasoning=reasoning,
-                )
-                penalized_confidence = self._penalize_confidence(
-                    rec.confidence,  # base
-                    missing_ratio=missing_ratio,
-                    freshness_minutes=data_freshness_minutes,
-                )
-                rec.confidence = penalized_confidence
-                recommendations.append(rec)
-            if btts_confidence > 0.5:
-                selection = "Yes" if btts_yes_prob > btts_no_prob else "No"
-                reasoning = (
-                    "Высокая вероятность того, что обе команды забьют"
-                    if selection == "Yes"
-                    else "Высокая вероятность того, что одна из команд не забьёт"
-                )
-                rec = BettingRecommendation(
-                    market="BTTS",
-                    selection=selection,
-                    confidence=btts_confidence,
-                    risk_level=btts_risk,
-                    reasoning=reasoning,
-                )
-                penalized_confidence = self._penalize_confidence(
-                    rec.confidence,  # base
-                    missing_ratio=missing_ratio,
-                    freshness_minutes=data_freshness_minutes,
-                )
-                rec.confidence = penalized_confidence
-                recommendations.append(rec)
-            # === Bivariate Poisson adjustment ===
-            if (
-                self.settings.MODEL_FLAGS.get("enable_bivariate_poisson", False)
-                and HAS_BIVARIATE_POISSON
-            ):
-                try:
-                    # Bivariate Poisson коррекции (безопасный вызов)
-                    try:
-                        rho = estimate_rho(match_context)
-                    except Exception:
-                        rho = 0.0
-                    bivar_model = BivariatePoisson(lambda_home, lambda_away, rho)
-                    btts_yes_corr, btts_no_corr = bivar_model.calculate_btts()
-                    over_corr, under_corr = bivar_model.calculate_totals()
-                    btts_corr_probs = {"yes": btts_yes_corr, "no": btts_no_corr}
-                    total_corr_probs = {"over": over_corr, "under": under_corr}
-                    # Скорректированные вероятности BTTS/Тоталов (ключи {'yes','no'} и {'over','under'})
-                    btts_confidence = self.compute_confidence_from_margin(btts_corr_probs)
-                    total_confidence = self.compute_confidence_from_margin(total_corr_probs)
-                    if btts_yes_corr > 0.5 and not any(
-                        r.market == "BTTS" and r.selection == "Yes" for r in recommendations
-                    ):
-                        risk_level = (
-                            RiskLevel.HIGH
-                            if btts_confidence < 0.1
-                            else RiskLevel.MEDIUM
-                            if btts_confidence < 0.25
-                            else RiskLevel.LOW
-                        )
-                        rec = BettingRecommendation(
-                            market="BTTS",
-                            selection="Yes",
-                            confidence=btts_confidence,
-                            risk_level=risk_level,
-                            reasoning="Высокая вероятность 'Обе забьют' (с корреляцией)",
-                        )
-                        penalized_confidence = self._penalize_confidence(
-                            rec.confidence,  # base
-                            missing_ratio=missing_ratio,
-                            freshness_minutes=data_freshness_minutes,
-                        )
-                        rec.confidence = penalized_confidence
-                        recommendations.append(rec)
-                    if over_corr > 0.5 and not any(
-                        r.market == "Totals" and r.selection == "Over" for r in recommendations
-                    ):
-                        risk_level = (
-                            RiskLevel.HIGH
-                            if total_confidence < 0.1
-                            else RiskLevel.MEDIUM
-                            if total_confidence < 0.25
-                            else RiskLevel.LOW
-                        )
-                        rec = BettingRecommendation(
-                            market="Totals",
-                            selection="Over",
-                            confidence=total_confidence,
-                            risk_level=risk_level,
-                            reasoning="Высокая вероятность Over (с корреляцией)",
-                        )
-                        penalized_confidence = self._penalize_confidence(
-                            rec.confidence,  # base
-                            missing_ratio=missing_ratio,
-                            freshness_minutes=data_freshness_minutes,
-                        )
-                        rec.confidence = penalized_confidence
-                        recommendations.append(rec)
-                except Exception as bivar_error:
-                    logger.error(f"Ошибка при использовании Bivariate Poisson: {bivar_error}")
-            return recommendations
-        except Exception as e:
-            logger.error(f"Ошибка при генерации рекомендаций: {e}")
-            return []
+        *,
+        seed: int,
+        n_sims: int,
+    ) -> dict[str, Any]:
+        rng = np.random.default_rng(seed)
+        home_goals = rng.poisson(lambda_home, n_sims)
+        away_goals = rng.poisson(lambda_away, n_sims)
+        total = float(n_sims)
 
+        counts = Counter(zip(home_goals.tolist(), away_goals.tolist(), strict=False))
 
-# Создание экземпляра движка рекомендаций
-recommendation_engine = RecommendationEngine(sportmonks_client)
+        win_home = sum(count for (h, a), count in counts.items() if h > a)
+        win_away = sum(count for (h, a), count in counts.items() if h < a)
+        draws = total - win_home - win_away
+
+        probs = _normalize_triplet(
+            {
+                "H": win_home / total,
+                "D": draws / total,
+                "A": win_away / total,
+            }
+        )
+
+        over = sum(count for (h, a), count in counts.items() if h + a > 2)
+        under = total - over
+        over_prob, under_prob = _normalize_pair(over / total, under / total)
+
+        btts_yes = sum(count for (h, a), count in counts.items() if h > 0 and a > 0)
+        btts_no = total - btts_yes
+        btts_yes_prob, btts_no_prob = _normalize_pair(btts_yes / total, btts_no / total)
+
+        score_probs: list[dict[str, float]] = []
+        for (h, a), count in counts.items():
+            prob = count / total
+            if prob <= 0 or not math.isfinite(prob):
+                continue
+            score_probs.append({"score": f"{h}:{a}", "probability": prob})
+
+        scoreline_topk = sorted(
+            score_probs,
+            key=lambda item: (-item["probability"], item["score"]),
+        )[: self._scoreline_topk]
+
+        return {
+            "probs": probs,
+            "totals": {
+                "over_2_5": over_prob,
+                "under_2_5": under_prob,
+                "btts_yes": btts_yes_prob,
+                "btts_no": btts_no_prob,
+            },
+            "scoreline_topk": scoreline_topk,
+        }
+
+    @staticmethod
+    def _assert_invariants(simulation: Mapping[str, Any]) -> None:
+        probs = simulation["probs"]
+        totals = simulation["totals"]
+
+        prob_sum = sum(probs.values())
+        if not math.isfinite(prob_sum) or abs(prob_sum - 1.0) > _PROB_TOLERANCE:
+            raise PredictionEngineError("1X2 probabilities failed to normalise")
+
+        over_sum = totals["over_2_5"] + totals["under_2_5"]
+        if not math.isfinite(over_sum) or abs(over_sum - 1.0) > _PROB_TOLERANCE:
+            raise PredictionEngineError("Totals probabilities failed to normalise")
+
+        btts_sum = totals["btts_yes"] + totals["btts_no"]
+        if not math.isfinite(btts_sum) or abs(btts_sum - 1.0) > _PROB_TOLERANCE:
+            raise PredictionEngineError("BTTS probabilities failed to normalise")
+
+        scoreline_topk = simulation.get("scoreline_topk", [])
+        if scoreline_topk:
+            probs_list = [item["probability"] for item in scoreline_topk]
+            if probs_list != sorted(probs_list, reverse=True):
+                raise PredictionEngineError("Scoreline topk is not sorted by probability")
+            if any(prob <= 0 or not math.isfinite(prob) for prob in probs_list):
+                raise PredictionEngineError("Scoreline probabilities contain invalid values")

--- a/tests/ml/test_prediction_invariants.py
+++ b/tests/ml/test_prediction_invariants.py
@@ -1,0 +1,212 @@
+"""
+@file: tests/ml/test_prediction_invariants.py
+@description: Invariant tests for the recommendation engine prediction payload.
+@dependencies: pytest, hypothesis, numpy, sqlalchemy
+@created: 2025-09-20
+"""
+from __future__ import annotations
+
+import math
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given, settings  # type: ignore  # noqa: E402
+from hypothesis import strategies as st  # type: ignore  # noqa: E402
+from hypothesis.extra.asyncio import async_test  # type: ignore  # noqa: E402
+from sqlalchemy import text
+
+from database import DBRouter
+from services.recommendation_engine import RecommendationEngine
+
+pytestmark = pytest.mark.needs_np
+
+
+async def _create_schema(router: DBRouter) -> None:
+    async with router.session() as session:
+        await session.execute(
+            text(
+                """
+                CREATE TABLE fixtures (
+                    id INTEGER PRIMARY KEY,
+                    home_team TEXT NOT NULL,
+                    away_team TEXT NOT NULL,
+                    league TEXT,
+                    utc_kickoff TEXT,
+                    home_team_id INTEGER,
+                    away_team_id INTEGER
+                )
+                """
+            )
+        )
+        await session.execute(
+            text(
+                """
+                CREATE TABLE team_metrics (
+                    team_id INTEGER PRIMARY KEY,
+                    team_name TEXT NOT NULL,
+                    attack_strength REAL,
+                    defence_strength REAL,
+                    lambda_for REAL,
+                    lambda_against REAL,
+                    xg_for REAL,
+                    xg_against REAL
+                )
+                """
+            )
+        )
+        await session.commit()
+
+
+@pytest.fixture
+async def engine_with_data() -> tuple[RecommendationEngine, Callable[[float, float], Awaitable[None]]]:
+    router = DBRouter(dsn="sqlite+aiosqlite:///:memory:")
+    await _create_schema(router)
+    async with router.session() as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO fixtures (id, home_team, away_team, league, utc_kickoff, home_team_id, away_team_id)
+                VALUES (:id, :home, :away, :league, :kickoff, :home_id, :away_id)
+                """
+            ),
+            {
+                "id": 1,
+                "home": "Alpha FC",
+                "away": "Beta United",
+                "league": "Test League",
+                "kickoff": "2025-09-20T18:30:00+00:00",
+                "home_id": 10,
+                "away_id": 20,
+            },
+        )
+        await session.execute(
+            text(
+                """
+                INSERT INTO team_metrics (
+                    team_id, team_name, attack_strength, defence_strength,
+                    lambda_for, lambda_against, xg_for, xg_against
+                )
+                VALUES
+                    (:home_id, :home_name, 1.4, 0.9, 1.6, 1.1, 1.5, 1.0),
+                    (:away_id, :away_name, 1.2, 1.0, 1.3, 1.2, 1.2, 1.1)
+                """
+            ),
+            {
+                "home_id": 10,
+                "home_name": "Alpha FC",
+                "away_id": 20,
+                "away_name": "Beta United",
+            },
+        )
+        await session.commit()
+
+    engine = RecommendationEngine(router)
+
+    async def _update(home_rate: float, away_rate: float) -> None:
+        async with router.session() as session:
+            await session.execute(
+                text(
+                    """
+                    UPDATE team_metrics
+                    SET lambda_for = :rate,
+                        xg_for = :rate,
+                        attack_strength = :rate
+                    WHERE team_id = :team_id
+                    """
+                ),
+                {"rate": home_rate, "team_id": 10},
+            )
+            await session.execute(
+                text(
+                    """
+                    UPDATE team_metrics
+                    SET lambda_against = :rate,
+                        xg_against = :rate,
+                        defence_strength = :rate
+                    WHERE team_id = :team_id
+                    """
+                ),
+                {"rate": away_rate, "team_id": 10},
+            )
+            await session.execute(
+                text(
+                    """
+                    UPDATE team_metrics
+                    SET lambda_for = :rate,
+                        xg_for = :rate,
+                        attack_strength = :rate
+                    WHERE team_id = :team_id
+                    """
+                ),
+                {"rate": away_rate, "team_id": 20},
+            )
+            await session.execute(
+                text(
+                    """
+                    UPDATE team_metrics
+                    SET lambda_against = :rate,
+                        xg_against = :rate,
+                        defence_strength = :rate
+                    WHERE team_id = :team_id
+                    """
+                ),
+                {"rate": home_rate, "team_id": 20},
+            )
+            await session.commit()
+
+    yield engine, _update
+    await router.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_probabilities_and_totals_are_normalized(engine_with_data) -> None:
+    engine, _ = engine_with_data
+    result = await engine.generate_prediction("1", seed=42, n_sims=5000)
+
+    probs = result["probs"]
+    assert pytest.approx(sum(probs.values()), rel=1e-6, abs=1e-6) == 1.0
+    assert all(prob >= 0 for prob in probs.values())
+
+    totals = result["totals"]
+    assert pytest.approx(totals["over_2_5"] + totals["under_2_5"], rel=1e-6, abs=1e-6) == 1.0
+    assert pytest.approx(totals["btts_yes"] + totals["btts_no"], rel=1e-6, abs=1e-6) == 1.0
+    assert all(value >= 0 for value in totals.values())
+
+    topk = result["scoreline_topk"]
+    assert topk == sorted(topk, key=lambda item: item["probability"], reverse=True)
+    assert all(item["probability"] > 0 for item in topk)
+
+
+@pytest.mark.asyncio
+async def test_seed_stability(engine_with_data) -> None:
+    engine, _ = engine_with_data
+    first = await engine.generate_prediction("1", seed=7, n_sims=4000)
+    second = await engine.generate_prediction("1", seed=7, n_sims=4000)
+    assert first["probs"] == second["probs"]
+    assert first["totals"] == second["totals"]
+    assert first["scoreline_topk"] == second["scoreline_topk"]
+
+    different_seed = await engine.generate_prediction("1", seed=8, n_sims=4000)
+    assert different_seed["probs"] != first["probs"] or different_seed["totals"] != first["totals"]
+
+
+@given(
+    home_rate=st.floats(min_value=0.05, max_value=6.0, allow_nan=False, allow_infinity=False),
+    away_rate=st.floats(min_value=0.05, max_value=6.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=20, deadline=None)
+@async_test()
+async def test_no_nan_for_extreme_lambdas(
+    engine_with_data: tuple[RecommendationEngine, Callable[[float, float], Awaitable[None]]],
+    home_rate: float,
+    away_rate: float,
+) -> None:
+    engine, update_rates = engine_with_data
+    await update_rates(home_rate, away_rate)
+    result = await engine.generate_prediction("1", seed=11, n_sims=3000)
+
+    assert all(not math.isnan(prob) and prob >= 0 for prob in result["probs"].values())
+    totals = result["totals"]
+    assert all(not math.isnan(value) and value >= 0 for value in totals.values())

--- a/tests/workers/test_prediction_worker.py
+++ b/tests/workers/test_prediction_worker.py
@@ -1,0 +1,197 @@
+"""
+@file: tests/workers/test_prediction_worker.py
+@description: Tests for the dependency-injected prediction worker and queue interactions.
+@dependencies: pytest
+@created: 2025-09-20
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from core.services.predictor import PredictorServiceError
+from workers.prediction_worker import (
+    InvalidJobError,
+    LockAcquisitionError,
+    PredictionJob,
+    PredictionWorker,
+    PredictionWorkerError,
+)
+from workers.queue_adapter import IQueueAdapter, TaskStatus
+
+
+class InMemoryQueueAdapter(IQueueAdapter):
+    def __init__(self) -> None:
+        self.started: list[tuple[str, dict[str, Any] | None]] = []
+        self.finished: dict[str, dict[str, Any]] = {}
+        self.failed: dict[str, dict[str, Any]] = {}
+
+    async def mark_started(self, job_id: str, *, meta: dict[str, Any] | None = None) -> None:
+        self.started.append((job_id, meta))
+
+    async def mark_finished(self, job_id: str, payload: dict[str, Any]) -> None:
+        self.finished[job_id] = payload
+
+    async def mark_failed(
+        self,
+        job_id: str,
+        reason: str,
+        *,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        self.failed[job_id] = {"reason": reason, "details": details or {}}
+
+
+@dataclass
+class FakeLock:
+    should_acquire: bool = True
+    released: bool = False
+    raise_on_release: bool = False
+
+    async def acquire(self) -> bool:
+        return self.should_acquire
+
+    async def release(self) -> None:
+        if self.raise_on_release:
+            raise RuntimeError("release failed")
+        self.released = True
+
+
+class FakeRedisClient:
+    def __init__(self, lock: FakeLock) -> None:
+        self.lock_calls: list[tuple[str, float | None, float | None]] = []
+        self._lock = lock
+
+    def lock(self, key: str, timeout: float | None, blocking_timeout: float | None) -> FakeLock:
+        self.lock_calls.append((key, timeout, blocking_timeout))
+        return self._lock
+
+
+class DummyRedisFactory:
+    def __init__(self, client: FakeRedisClient | None) -> None:
+        self._client = client
+
+    async def get_client(self) -> FakeRedisClient | None:
+        return self._client
+
+
+class StubPredictor:
+    def __init__(self, *, result: dict[str, Any] | None = None, error: Exception | None = None) -> None:
+        self._result = result or {
+            "probs": {"H": 0.4, "D": 0.3, "A": 0.3},
+            "totals": {
+                "over_2_5": 0.55,
+                "under_2_5": 0.45,
+                "btts_yes": 0.6,
+                "btts_no": 0.4,
+            },
+            "scoreline_topk": [{"score": "1:0", "probability": 0.18}],
+        }
+        self._error = error
+        self.calls: list[dict[str, Any]] = []
+
+    async def generate_prediction(
+        self,
+        fixture_id: str | None = None,
+        *,
+        home: str | None = None,
+        away: str | None = None,
+        seed: int,
+        n_sims: int,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "fixture_id": fixture_id,
+                "home": home,
+                "away": away,
+                "seed": seed,
+                "n_sims": n_sims,
+            }
+        )
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_worker_happy_path_marks_statuses() -> None:
+    queue = InMemoryQueueAdapter()
+    lock = FakeLock()
+    redis_factory = DummyRedisFactory(FakeRedisClient(lock))
+    predictor = StubPredictor()
+    worker = PredictionWorker(
+        predictor=predictor,
+        queue=queue,
+        redis_factory=redis_factory,
+        lock_timeout=3.0,
+        lock_blocking_timeout=0.1,
+    )
+
+    job = PredictionJob(job_id="job-1", fixture_id="1", home="Alpha", away="Beta")
+    result = await worker.handle(job)
+
+    assert queue.started[0][0] == "job-1"
+    assert queue.started[0][1]["status"] == TaskStatus.STARTED.value
+    assert queue.finished["job-1"]["status"] == TaskStatus.FINISHED.value
+    assert "result" in queue.finished["job-1"]
+    assert lock.released is True
+    assert predictor.calls and predictor.calls[0]["seed"] > 0
+    assert result["probs"]["H"] == pytest.approx(0.4)
+
+
+@pytest.mark.asyncio
+async def test_worker_propagates_engine_failure() -> None:
+    queue = InMemoryQueueAdapter()
+    redis_factory = DummyRedisFactory(None)
+    predictor = StubPredictor(error=PredictorServiceError("boom"))
+    worker = PredictionWorker(
+        predictor=predictor,
+        queue=queue,
+        redis_factory=redis_factory,
+    )
+
+    job = PredictionJob(job_id="job-err", fixture_id="1", home="Alpha", away="Beta")
+    with pytest.raises(PredictionWorkerError):
+        await worker.handle(job)
+
+    assert queue.failed["job-err"]["reason"] == "prediction_failed"
+
+
+@pytest.mark.asyncio
+async def test_worker_handles_lock_timeout() -> None:
+    queue = InMemoryQueueAdapter()
+    lock = FakeLock(should_acquire=False)
+    redis_factory = DummyRedisFactory(FakeRedisClient(lock))
+    predictor = StubPredictor()
+    worker = PredictionWorker(
+        predictor=predictor,
+        queue=queue,
+        redis_factory=redis_factory,
+    )
+
+    job = PredictionJob(job_id="job-lock", fixture_id="1", home="Alpha", away="Beta")
+    with pytest.raises(LockAcquisitionError):
+        await worker.handle(job)
+
+    assert queue.failed["job-lock"]["reason"] == "lock_timeout"
+    assert "prediction already in progress" in queue.failed["job-lock"]["details"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_worker_validates_job_payload() -> None:
+    queue = InMemoryQueueAdapter()
+    redis_factory = DummyRedisFactory(None)
+    predictor = StubPredictor()
+    worker = PredictionWorker(
+        predictor=predictor,
+        queue=queue,
+        redis_factory=redis_factory,
+    )
+
+    job = PredictionJob(job_id="invalid")
+    with pytest.raises(InvalidJobError):
+        await worker.handle(job)
+
+    assert queue.failed["invalid"]["reason"] == "invalid_job"

--- a/workers/queue_adapter.py
+++ b/workers/queue_adapter.py
@@ -1,0 +1,42 @@
+"""
+@file: workers/queue_adapter.py
+@description: Protocol and helpers for prediction queue status reporting.
+@dependencies: enum, typing
+@created: 2025-09-20
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Protocol
+
+
+class TaskStatus(str, Enum):
+    """Standardised task status compatible with RQ semantics."""
+
+    QUEUED = "queued"
+    STARTED = "started"
+    FINISHED = "finished"
+    FAILED = "failed"
+
+
+class QueueAdapterError(RuntimeError):
+    """Raised when queue adapter encounters unrecoverable state."""
+
+
+class IQueueAdapter(Protocol):
+    """Protocol describing queue adapter interactions used by the worker."""
+
+    async def mark_started(self, job_id: str, *, meta: dict[str, Any] | None = None) -> None:
+        """Mark job as started and optionally persist metadata."""
+
+    async def mark_finished(self, job_id: str, payload: dict[str, Any]) -> None:
+        """Persist successful result and final status."""
+
+    async def mark_failed(
+        self,
+        job_id: str,
+        reason: str,
+        *,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        """Persist failure status with structured details."""

--- a/workers/redis_factory.py
+++ b/workers/redis_factory.py
@@ -1,0 +1,78 @@
+"""
+@file: workers/redis_factory.py
+@description: Lazy Redis client factory with masking and graceful fallbacks.
+@dependencies: redis.asyncio (optional), config.get_settings
+@created: 2025-09-20
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from config import get_settings
+from logger import logger
+
+try:  # pragma: no cover - optional dependency in tests
+    from redis.asyncio import Redis, from_url
+except Exception:  # pragma: no cover
+    Redis = Any  # type: ignore[assignment]
+    from_url = None  # type: ignore[assignment]
+
+
+def _mask(url: str) -> str:
+    if not url:
+        return ""
+    parts = urlsplit(url)
+    netloc = parts.netloc
+    if "@" in netloc:
+        _, host = netloc.rsplit("@", 1)
+        netloc = f"***@{host}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
+class RedisFactory:
+    """Factory providing shared Redis client instances for workers."""
+
+    def __init__(self, *, url: str | None = None, client: Redis | None = None) -> None:
+        self._configured_url = url
+        self._client: Redis | None = client
+
+    def _url(self) -> str:
+        if self._configured_url is not None:
+            return self._configured_url
+        settings = get_settings()
+        return settings.REDIS_URL
+
+    async def get_client(self) -> Redis | None:
+        if self._client is not None:
+            return self._client
+        if from_url is None:  # dependency missing
+            logger.warning("redis.asyncio module unavailable; skipping Redis connection")
+            return None
+        url = self._url()
+        try:
+            client = from_url(url, encoding="utf-8", decode_responses=True)
+            await client.ping()
+        except Exception as exc:
+            logger.warning("Redis connection failed for %s: %s", _mask(url), exc)
+            return None
+        logger.debug("Redis connection initialised for %s", _mask(url))
+        self._client = client
+        return self._client
+
+    @asynccontextmanager
+    async def client(self) -> AsyncIterator[Redis | None]:
+        client = await self.get_client()
+        yield client
+
+    async def close(self) -> None:
+        if self._client is None:
+            return
+        try:
+            await self._client.close()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.debug("Redis client close failed: %s", exc)
+        finally:
+            self._client = None


### PR DESCRIPTION
## Summary
- replace the legacy recommendation engine with a DB-backed, seed-stable generator and expose a typed predictor facade
- rebuild the prediction worker around dependency injection, queue status reporting, and redis locks
- add invariant-focused ML and worker tests plus update README/docs/tasktracker/changelog entries

## Testing
- ruff check services/*.py core/services/*.py workers/*.py
- pytest tests/ml -q
- pytest tests/workers/test_prediction_worker.py -q
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca575ccd28832ebd18b8cdfb8ca9b0