### PR TITLE
feat: add production docker packaging for Amvera

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# @file: .dockerignore
+# @description: Build context exclusions for Docker image
+# @created: 2025-09-21
+
+.git
+.gitignore
+.github/
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.dylib
+*.egg-info/
+.eggs/
+.dist-info/
+.build/
+build/
+dist/
+htmlcov/
+.coverage*
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.cache/
+.DS_Store
+.vscode/
+.env
+.env.*
+*.log
+*.tmp
+*.sqlite
+*.db
+
+# Development and documentation assets
+reports/
+docs/
+tests/
+wheels/
+patches/
+tickets/
+notebooks/
+experiments/
+
+# Local virtual environments
+.venv/
+venv/
+ENV/
+env/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2025-09-21] - E5: Amvera deployment pipeline
+### Added
+- Production-ready multi-stage `Dockerfile`, `.dockerignore` and entrypoint script for Amvera containers.
+- `scripts/prestart.py` orchestrating Alembic upgrades plus Postgres/Redis health checks with masked DSN logging.
+
+### Changed
+- `Makefile` targets for `docker-build`/`docker-run` tagging images with `APP_VERSION` and `GIT_SHA`.
+- `README.md` now documents Amvera deployment flow, required environment and prestart behaviour.
+
+### Fixed
+- Exported `mask_dsn()` from `database.db_router` and added `RedisFactory.health_check()` for reliable startup diagnostics.
+
 ## [2025-09-20] - E4: Recommendation engine invariants
 ### Added
 - Normalised `RecommendationEngine.generate_prediction` payload and predictor facade in `core/services`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+# @file: Dockerfile
+# @description: Multi-stage Dockerfile for production-ready Telegram bot deployment
+# @created: 2025-09-21
+
+FROM python:3.11-slim AS base
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_DEFAULT_TIMEOUT=100
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        build-essential \
+        gcc \
+        g++ \
+        make \
+        libpq-dev \
+        libffi-dev \
+        libssl-dev \
+        libopenblas-dev \
+        gfortran \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+
+FROM base AS builder
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+COPY requirements.txt constraints.txt ./
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt -c constraints.txt
+
+FROM python:3.11-slim AS runtime
+ARG APP_VERSION=0.0.0
+ARG GIT_SHA=dev
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    APP_VERSION=${APP_VERSION} \
+    GIT_SHA=${GIT_SHA}
+LABEL org.opencontainers.image.title="telegram-bot" \
+      org.opencontainers.image.version="${APP_VERSION}" \
+      org.opencontainers.image.revision="${GIT_SHA}"
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        libpq5 \
+        libffi8 \
+        libssl3 \
+        libopenblas0-pthread \
+        libstdc++6 \
+        libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY pyproject.toml requirements.txt constraints.txt ./
+COPY config.py logger.py main.py data_processor.py ./
+COPY app ./app
+COPY core ./core
+COPY database ./database
+COPY metrics ./metrics
+COPY ml ./ml
+COPY services ./services
+COPY storage ./storage
+COPY telegram ./telegram
+COPY workers ./workers
+COPY scripts/__init__.py scripts/prestart.py scripts/entrypoint.sh ./scripts/
+
+RUN chmod +x scripts/entrypoint.sh
+
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+USER app
+
+ENTRYPOINT ["./scripts/entrypoint.sh"]

--- a/database/db_router.py
+++ b/database/db_router.py
@@ -73,6 +73,12 @@ def _mask_dsn(dsn: str) -> str:
     return str(url)
 
 
+def mask_dsn(dsn: str) -> str:
+    """Public helper to safely mask database connection strings."""
+
+    return _mask_dsn(dsn)
+
+
 class DBRouter:
     """Manage async engines and sessions for primary and replica databases."""
 
@@ -303,4 +309,5 @@ __all__ = [
     "DatabaseStartupError",
     "EngineOptions",
     "get_db_router",
+    "mask_dsn",
 ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,15 @@
+## [2025-09-21] - E5: Подготовка Docker-окружения для Amvera
+### Добавлено
+- Многоступенчатый `Dockerfile`, `.dockerignore` и `scripts/entrypoint.sh` с проверкой обязательных переменных окружения.
+- `scripts/prestart.py`, выполняющий `alembic upgrade head` и health-check PostgreSQL/Redis с маскировкой DSN.
+
+### Изменено
+- `Makefile` получил цели `docker-build`/`docker-run`, использующие теги из `APP_VERSION` и `GIT_SHA`.
+- `README.md` дополнен разделом про деплой на Amvera и описанием prestart-процедуры.
+
+### Исправлено
+- Экспортирован `mask_dsn()` из `database.db_router` и добавлен `RedisFactory.health_check()` для корректной диагностики старта.
+
 ## [2025-09-20] - E4: Recommendation engine invariants
 ### Добавлено
 - Унифицированный `RecommendationEngine.generate_prediction` с нормализацией 1X2/Totals/BTTS и top-k счётов.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,13 @@
+## Задача: E5 — Production Docker/Entrypoint for Amvera
+- **Статус**: В процессе
+- **Описание**: Подготовить production Docker-образ с prestart-хуком (alembic + health-check) и обновить документацию под деплой на Amvera.
+- **Шаги выполнения**:
+  - [x] Добавить многоступенчатый Dockerfile и `.dockerignore`.
+  - [x] Реализовать `scripts/entrypoint.sh` и `scripts/prestart.py` с проверками БД/Redis.
+  - [x] Обновить Makefile/README/CHANGELOG/tasktracker под новый процесс деплоя.
+  - [ ] Прогнать `docker build`/`docker run` в окружении Amvera.
+- **Зависимости**: Dockerfile, .dockerignore, scripts/entrypoint.sh, scripts/prestart.py, Makefile, README.md, CHANGELOG.md, docs/changelog.md, docs/tasktracker.md, database/db_router.py, workers/redis_factory.py
+
 ## Задача: E4 — Recommendation engine invariants
 - **Статус**: Завершена
 - **Описание**: Нормализовать интерфейсы RecommendationEngine/PredictorService/воркера и гарантировать инварианты вероятностей.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# /**
+#  * @file: scripts/entrypoint.sh
+#  * @description: Container entrypoint orchestrating migrations, health checks and bot startup.
+#  * @dependencies: scripts/prestart.py, main.py
+#  * @created: 2025-09-21
+#  */
+set -euo pipefail
+
+required_env=(DATABASE_URL REDIS_URL TELEGRAM_BOT_TOKEN)
+
+for var in "${required_env[@]}"; do
+    if [[ -z "${!var:-}" ]]; then
+        printf '{"level":"ERROR","event":"env.missing","variable":"%s"}\n' "$var" >&2
+        exit 1
+    fi
+done
+
+printf '{"level":"INFO","event":"prestart.invoke"}\n'
+python -m scripts.prestart
+
+printf '{"level":"INFO","event":"bot.launch","command":"python -m main"}\n'
+exec python -m main

--- a/scripts/prestart.py
+++ b/scripts/prestart.py
@@ -1,0 +1,100 @@
+"""
+@file: scripts/prestart.py
+@description: Prestart routine for running migrations and service health checks.
+@dependencies: alembic, database.db_router, workers.redis_factory
+@created: 2025-09-21
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import text
+
+from config import Settings, get_settings
+from database.db_router import DBRouter, get_db_router, mask_dsn
+from logger import logger
+from workers.redis_factory import RedisFactory
+
+
+def _configure_alembic(settings: Settings) -> Config:
+    config = Config()
+    config.set_main_option("script_location", "database/migrations")
+    config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+    return config
+
+
+def run_migrations(settings: Settings) -> None:
+    masked_dsn = mask_dsn(settings.DATABASE_URL)
+    bound_logger = logger.bind(event="prestart.migrations", dsn=masked_dsn)
+    bound_logger.info("Running Alembic upgrade to head")
+    try:
+        command.upgrade(_configure_alembic(settings), "head")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        bound_logger.bind(error=str(exc)).error("Alembic upgrade failed")
+        raise
+    else:
+        bound_logger.info("Alembic upgrade finished")
+
+
+async def _probe_session(router: DBRouter, *, read_only: bool) -> None:
+    options = router.reader_options if read_only else router.writer_options
+    target = "reader" if read_only else "writer"
+    masked_dsn = mask_dsn(options.dsn)
+    probe_logger = logger.bind(event="prestart.healthcheck.db", target=target, dsn=masked_dsn)
+    probe_logger.info("Checking database connectivity")
+    try:
+        async with router.session(read_only=read_only) as session:
+            await session.execute(text("SELECT 1"))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        probe_logger.bind(error=str(exc)).error("Database connectivity check failed")
+        raise
+    else:
+        probe_logger.info("Database connection healthy")
+
+
+async def check_database(settings: Settings) -> None:
+    router = get_db_router(settings)
+    try:
+        await _probe_session(router, read_only=False)
+        if (
+            settings.DATABASE_URL_RO
+            or settings.DATABASE_URL_R
+            or router.reader_options.dsn != router.writer_options.dsn
+        ):
+            await _probe_session(router, read_only=True)
+    finally:
+        await router.shutdown()
+
+
+async def check_redis(settings: Settings) -> None:
+    factory = RedisFactory(url=settings.REDIS_URL)
+    try:
+        await factory.health_check()
+    finally:
+        await factory.close()
+
+
+async def run_health_checks(settings: Settings) -> None:
+    await check_database(settings)
+    await check_redis(settings)
+
+
+async def _async_main() -> None:
+    settings = get_settings()
+    run_migrations(settings)
+    await run_health_checks(settings)
+
+
+def main() -> None:
+    try:
+        asyncio.run(_async_main())
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.bind(event="prestart.failure", error=str(exc)).error("Prestart routine failed")
+        raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile, .dockerignore, and entrypoint to prepare an Amvera-ready image
- run Alembic migrations and Postgres/Redis health checks via a new prestart routine
- document the deployment flow, docker targets, and changelog/task tracker updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca66889e60832e862f996baa71b617