### PR TITLE
build: enforce coverage thresholds via coverage.xml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,20 @@
+# @file: .coveragerc
+# @description: Coverage.py configuration for enforcing statement thresholds
+# @created: 2025-09-23
+
+[run]
+source = .
+
+[report]
+show_missing = True
+skip_empty = True
+omit =
+    database/migrations/*
+    alembic/*
+    scripts/entrypoint.sh
+    scripts/*.sh
+    **/__init__.py
+    tests/*
+    docs/*
+    reports/*
+    *.pyi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,13 @@ jobs:
       - name: coverage
         run: make coverage-html
 
+      - name: coverage-enforce
+        run: python -m tools.coverage_enforce --summary-json reports/coverage_summary.json
+
       - name: reports
         run: |
           python reports/bot_e2e_snapshot.py
-          python reports/rc_summary.py --tests-passed --coverage-json coverage.json --summary-json reports/coverage_summary.json
+          python reports/rc_summary.py --tests-passed --summary-json reports/coverage_summary.json
 
       - name: artifacts
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2025-09-23] - E6.2: Coverage configuration hardening
+### Added
+- `.coveragerc` with statement coverage settings omitting migrations, documentation, tests and shell scripts.
+- `tools.coverage_enforce` module parsing `coverage.xml`, enforcing thresholds and exporting `reports/coverage_summary.json`.
+
+### Changed
+- `Makefile` targets `test-all` and `coverage-html` now emit `coverage.xml`, call the new enforcement tool and render HTML via `coverage html`.
+- CI pipeline adds a dedicated `coverage-enforce` step and README documents the new configuration and thresholds.
+
+### Fixed
+- Builds fail with exit code 2 when total coverage <80% or workers/database/services/core/services drop below 90% based on `coverage.xml` data.
+
 ## [2025-09-22] - E6: CI coverage & reports
 ### Added
 - Deterministic generators `reports/bot_e2e_snapshot.py` and `reports/rc_summary.py` with CI-friendly outputs.

--- a/Makefile
+++ b/Makefile
@@ -88,15 +88,16 @@ test-smoke:
 	pytest -q -m bot_smoke
 
 test-all:
-	rm -f coverage.json
-	pytest --cov=./ --cov-report=term-missing --cov-report=json:coverage.json
-	$(PY) -m scripts.enforce_coverage --coverage-json coverage.json --summary-json reports/coverage_summary.json
+        rm -f coverage.xml
+        pytest --cov=./ --cov-report=xml --cov-report=term-missing
+        $(PY) -m tools.coverage_enforce --summary-json reports/coverage_summary.json
 
 coverage-html:
-	rm -f coverage.json
-	rm -rf htmlcov
-	pytest --cov=./ --cov-report=html --cov-report=json:coverage.json
-	$(PY) -m scripts.enforce_coverage --coverage-json coverage.json --summary-json reports/coverage_summary.json
+        rm -f coverage.xml
+        rm -rf htmlcov
+        pytest --cov=./ --cov-report=xml --cov-report=term-missing
+        $(PY) -m tools.coverage_enforce --summary-json reports/coverage_summary.json
+        $(PY) -m coverage html
 
 pre-commit-smart:
 	@echo "[pre-commit smart] trying online first, with fallback to offline config"

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ GitHub Actions запускает единый job `pipeline` со стадия�
 - `make test-smoke` — только smoke-маршруты бота (`pytest -q -m bot_smoke`);
 - `make coverage-html` — полный pytest с coverage, HTML-отчётом и жёсткими порогами (`≥80%` total, `≥90%` для `workers/`, `database/`, `services/`, `core/services/`).
 
-Coverage валидируется скриптом `python -m scripts.enforce_coverage`, который также пишет срез `reports/coverage_summary.json`.
+Coverage валидируется скриптом `python -m tools.coverage_enforce`, который читает `coverage.xml`, проверяет пороги (≥80% total и ≥90% для `workers/`, `database/`, `services/`, `core/services/`) и обновляет `reports/coverage_summary.json`.
+Конфигурация `.coveragerc` исключает миграции, shell-скрипты, тесты, документацию и `__init__.py` без логики, чтобы в отчёт попадал только исполняемый код.
 На этапе `reports` формируются артефакты `reports/bot_e2e_snapshot.md` (детерминированные ответы `/help`, `/model`, `/today`, `/match`, `/predict`) и `reports/rc_summary.json`
 с полями `app_version`, `git_sha`, `tests_passed`, `coverage_total`, `coverage_critical_packages`, `docker_image_size_mb`, `timestamp_utc`.
 Финальный шаг публикует артефакт **coverage-and-reports** с HTML-покрытием (`htmlcov/index.html`) и новыми отчётами.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,15 @@
+## [2025-09-23] - E6.2: Жёсткая конфигурация coverage
+### Добавлено
+- `.coveragerc` с настройками statement coverage и исключениями для миграций, документации, тестов и shell-скриптов.
+- Модуль `tools.coverage_enforce`, читающий `coverage.xml`, проверяющий пороги и обновляющий `reports/coverage_summary.json`.
+
+### Изменено
+- Цели `Makefile` (`test-all`, `coverage-html`) теперь генерируют `coverage.xml`, вызывают новый enforcement и строят HTML через `coverage html`.
+- Workflow CI добавляет шаг `coverage-enforce`, README описывает конфигурацию `.coveragerc` и пороги пакетов.
+
+### Исправлено
+- Сборка падает с кодом 2 при покрытии <80% либо <90% по `workers/`, `database/`, `services/`, `core/services/` на основании `coverage.xml`.
+
 ## [2025-09-23] - E6: Покрытие отрицательных сценариев
 ### Добавлено
 - Юнит-тесты ошибок Telegram-команд (`tests/bot/test_handlers_errors.py`) и виджетов (`tests/telegram/test_widgets_escape.py`).

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,13 @@
+## Задача: E6.2 — Coverage thresholds enforcement
+- **Статус**: Завершена
+- **Описание**: Сконфигурировать coverage.py, исключить не-кодовые файлы и ввести жёсткие пороги по проекту и критическим пакетам без изменения бизнес-логики.
+- **Шаги выполнения**:
+  - [x] Создан `.coveragerc` с исключениями миграций, документации, тестов, shell-скриптов и `__init__.py` без логики.
+  - [x] Реализован `tools.coverage_enforce` для разбора `coverage.xml`, проверки порогов и выгрузки `reports/coverage_summary.json`.
+  - [x] Обновлены цели `Makefile` и workflow `ci.yml`, запускающие enforcement до генерации HTML-отчёта.
+  - [x] README, CHANGELOG и docs/changelog зафиксировали конфигурацию и требования.
+- **Зависимости**: .coveragerc, tools/coverage_enforce.py, Makefile, .github/workflows/ci.yml, README.md, CHANGELOG.md, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: E6 — Error handling coverage hardening
 - **Статус**: Завершена
 - **Описание**: Закрыть ветки ошибок Telegram-бота, очередей, DB router и prestart без изменения бизнес-логики.

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,9 @@
+"""
+@file: __init__.py
+@description: Tools package marker module.
+@created: 2025-09-23
+"""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/tools/coverage_enforce.py
+++ b/tools/coverage_enforce.py
@@ -1,0 +1,184 @@
+"""
+@file: coverage_enforce.py
+@description: Enforce Cobertura XML coverage thresholds for critical packages.
+@created: 2025-09-23
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+from xml.etree import ElementTree as ET
+
+TOTAL_MIN = 80.0
+CRITICAL_PKGS: dict[str, float] = {
+    "workers": 90.0,
+    "database": 90.0,
+    "services": 90.0,
+    "core/services": 90.0,
+}
+PACKAGE_PREFIXES: dict[str, tuple[str, ...]] = {
+    "workers": ("workers/",),
+    "database": ("database/",),
+    "services": ("services/",),
+    "core/services": ("core/services/",),
+}
+
+
+@dataclass(frozen=True)
+class FileCoverage:
+    covered: int
+    statements: int
+
+    @property
+    def percent(self) -> float:
+        if self.statements == 0:
+            return 100.0
+        return round((self.covered / self.statements) * 100.0, 2)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate coverage.xml against project thresholds",
+    )
+    parser.add_argument(
+        "--coverage-xml",
+        default="coverage.xml",
+        help="Path to Cobertura XML produced by pytest-cov",
+    )
+    parser.add_argument(
+        "--summary-json",
+        default=None,
+        help="Optional path to write computed coverage summary",
+    )
+    return parser.parse_args()
+
+
+def _normalize_path(value: str | None) -> str | None:
+    if not value:
+        return None
+    return value.replace("\\", "/")
+
+
+def _collect_file_coverages(root: ET.Element) -> dict[str, FileCoverage]:
+    files: dict[str, FileCoverage] = {}
+    for class_node in root.findall(".//class"):
+        filename = _normalize_path(class_node.get("filename"))
+        if not filename:
+            continue
+        covered = 0
+        statements = 0
+        for line in class_node.findall(".//line"):
+            hits = line.get("hits")
+            if hits is None:
+                continue
+            try:
+                hit_count = int(float(hits))
+            except ValueError:
+                hit_count = 0
+            statements += 1
+            if hit_count > 0:
+                covered += 1
+        if filename in files:
+            prev = files[filename]
+            files[filename] = FileCoverage(prev.covered + covered, prev.statements + statements)
+        else:
+            files[filename] = FileCoverage(covered, statements)
+    return files
+
+
+def _aggregate_for_prefixes(files: dict[str, FileCoverage], prefixes: Iterable[str]) -> FileCoverage:
+    covered = 0
+    statements = 0
+    normalized_prefixes = tuple(prefix.replace("\\", "/") for prefix in prefixes)
+    for path, metrics in files.items():
+        if any(path.startswith(prefix) for prefix in normalized_prefixes):
+            covered += metrics.covered
+            statements += metrics.statements
+    return FileCoverage(covered, statements)
+
+
+def _compute_total_from_root(root: ET.Element, files: dict[str, FileCoverage]) -> FileCoverage:
+    covered_attr = root.get("lines-covered")
+    valid_attr = root.get("lines-valid")
+    try:
+        covered = int(float(covered_attr)) if covered_attr is not None else None
+    except ValueError:
+        covered = None
+    try:
+        statements = int(float(valid_attr)) if valid_attr is not None else None
+    except ValueError:
+        statements = None
+    if covered is not None and statements is not None:
+        return FileCoverage(covered, statements)
+    return FileCoverage(
+        sum(item.covered for item in files.values()),
+        sum(item.statements for item in files.values()),
+    )
+
+
+def _write_summary(path: str | Path, total: float, packages: dict[str, float]) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "coverage_total": total,
+        "coverage_critical_packages": packages,
+    }
+    target.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    xml_path = Path(args.coverage_xml)
+    if not xml_path.is_file():
+        print("coverage.xml not found", file=sys.stderr)
+        sys.exit(1)
+    try:
+        root = ET.parse(xml_path).getroot()
+    except ET.ParseError as exc:
+        print(f"Failed to parse coverage XML: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    files = _collect_file_coverages(root)
+    total_metrics = _compute_total_from_root(root, files)
+    package_metrics: dict[str, float] = {}
+    for package, threshold in CRITICAL_PKGS.items():
+        prefixes = PACKAGE_PREFIXES.get(package, (f"{package}/",))
+        metrics = _aggregate_for_prefixes(files, prefixes)
+        package_metrics[package] = metrics.percent
+
+    total_percent = total_metrics.percent
+
+    if args.summary_json:
+        _write_summary(args.summary_json, total_percent, package_metrics)
+
+    print("Coverage summary (statements):")
+    print(f"  total: {total_percent:.2f}% (required {TOTAL_MIN:.2f}%)")
+    for package, threshold in CRITICAL_PKGS.items():
+        value = package_metrics.get(package, 0.0)
+        print(f"  {package}: {value:.2f}% (required {threshold:.2f}%)")
+
+    failures: list[str] = []
+    if total_percent < TOTAL_MIN:
+        failures.append(
+            f"Total coverage {total_percent:.2f}% is below required {TOTAL_MIN:.2f}%"
+        )
+    for package, threshold in CRITICAL_PKGS.items():
+        value = package_metrics.get(package, 0.0)
+        if value < threshold:
+            failures.append(
+                f"Package '{package}' coverage {value:.2f}% is below required {threshold:.2f}%"
+            )
+
+    if failures:
+        for message in failures:
+            print(message, file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a dedicated `.coveragerc` to filter non-source files from coverage reports
- implement `tools.coverage_enforce` that parses `coverage.xml`, validates thresholds and refreshes the coverage summary
- update Makefile, CI workflow and docs to run the new enforcement before generating HTML reports

## Testing
- pytest --cov=./ --cov-report=xml --cov-report=term-missing
- python -m tools.coverage_enforce --summary-json reports/coverage_summary.json *(fails: current coverage is below configured thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_68ca797e3084832ead78b010eca52cd9