### PR TITLE
feat(workers): add redis factory retry backoff

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,14 @@
+## [2025-10-01] - E6.17: Redis factory retry coverage
+### Добавлено
+- Юнит-тесты `tests/database/test_redis_factory_backoff.py` моделируют backoff с jitter и успешное переподключение RedisFactory.
+- `workers/redis_factory.RedisFactory` поддерживает экспоненциальный backoff, jitter и маскирование DSN при повторных попытках.
+
+### Изменено
+- Логика переподключения RedisFactory использует биндинг logger для маскировки DSN и повторные попытки с контролируемыми задержками.
+
+### Исправлено
+- Исключение при исчерпании повторных попыток RedisFactory содержит понятное сообщение без утечки секретов.
+
 ## [2025-09-30] - E6.16: Prediction worker log hardening
 ### Добавлено
 - Расширены регресс-тесты `tests/workers/test_prediction_worker_errors.py` для проверки маскировки логов,

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: E6.17 — Redis factory retry coverage
+- **Статус**: Завершена
+- **Описание**: Зафиксировать повторные попытки RedisFactory с экспоненциальным backoff, jitter и маскировкой DSN.
+- **Шаги выполнения**:
+  - [x] Добавлены тесты backoff и jitter `tests/database/test_redis_factory_backoff.py` с контролем задержек и логов.
+  - [x] Расширен `workers/redis_factory.RedisFactory` параметрами повторных попыток и безопасным логированием.
+  - [x] Обновлены записи changelog/tasktracker для задачи E6.17.
+- **Зависимости**: workers/redis_factory.py, tests/database/test_redis_factory_backoff.py, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: E6.16 — Prediction worker log hardening
 - **Статус**: Завершена
 - **Описание**: Уточнить негативные тесты воркера предсказаний, зафиксировать маскирование логов и контроль таймаутов

--- a/tests/database/test_redis_factory_backoff.py
+++ b/tests/database/test_redis_factory_backoff.py
@@ -1,0 +1,194 @@
+"""
+@file: tests/database/test_redis_factory_backoff.py
+@description: Retry and masking behaviour for RedisFactory connections.
+@dependencies: workers.redis_factory, pytest
+@created: 2025-10-01
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from itertools import chain, repeat
+
+import pytest
+
+import workers.redis_factory as redis_factory
+
+
+class _StubLogger:
+    def __init__(self) -> None:
+        self.records: list[dict[str, object]] = []
+
+    def bind(self, **kwargs):
+        self.records.append({"type": "bind", "kwargs": kwargs})
+        return self
+
+    def debug(self, message, *args) -> None:  # pragma: no cover - helper for completeness
+        self.records.append({"level": "debug", "message": message, "args": args})
+
+    def info(self, message, *args) -> None:  # pragma: no cover - helper for completeness
+        self.records.append({"level": "info", "message": message, "args": args})
+
+    def warning(self, message, *args) -> None:
+        self.records.append({"level": "warning", "message": message, "args": args})
+
+    def error(self, message, *args) -> None:  # pragma: no cover - helper for completeness
+        self.records.append({"level": "error", "message": message, "args": args})
+
+
+class _AsyncioProxy:
+    def __init__(self, sleep_func):
+        self._sleep = sleep_func
+
+    async def sleep(self, delay: float) -> None:
+        await self._sleep(delay)
+
+    def __getattr__(self, name: str):  # pragma: no cover - defensive fallback
+        return getattr(asyncio, name)
+
+
+class _RandomProxy:
+    def __init__(self, uniform_func):
+        self._uniform = uniform_func
+
+    def uniform(self, start: float, end: float) -> float:
+        return self._uniform(start, end)
+
+    def __getattr__(self, name: str):  # pragma: no cover - defensive fallback
+        return getattr(random, name)
+
+
+@pytest.mark.asyncio
+async def test_ping_eventually_succeeds_with_backoff_and_jitter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = {"count": 0}
+    sleep_calls: list[float] = []
+    jitter_values = chain([0.001, 0.002], repeat(0.0))
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    def fake_uniform(start: float, end: float) -> float:
+        return next(jitter_values)
+
+    monkeypatch.setattr(
+        redis_factory,
+        "asyncio",
+        _AsyncioProxy(fake_sleep),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        redis_factory,
+        "random",
+        _RandomProxy(fake_uniform),
+        raising=False,
+    )
+
+    class FlakyRedis:
+        def __init__(self) -> None:
+            self.ping_calls = 0
+
+        async def ping(self) -> None:
+            self.ping_calls += 1
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                raise RuntimeError(f"ping failed {attempts['count']}")
+
+        async def close(self) -> None:  # pragma: no cover - cleanup hook
+            return None
+
+    clients: list[FlakyRedis] = []
+
+    def fake_from_url(*_args, **_kwargs) -> FlakyRedis:
+        client = FlakyRedis()
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(redis_factory, "from_url", fake_from_url)
+
+    factory = redis_factory.RedisFactory(
+        url="redis://:secret@localhost:6379/0",
+        max_retries=5,
+        base_delay=0.05,
+        max_delay=0.2,
+        jitter=0.01,
+    )
+
+    client = await factory.get_client()
+
+    assert client is clients[-1]
+    assert attempts["count"] == 3
+    assert sleep_calls == pytest.approx([0.051, 0.102])
+
+
+@pytest.mark.asyncio
+async def test_ping_failure_masks_dsn_and_raises_after_max_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    def fake_uniform(start: float, end: float) -> float:
+        return 0.0
+
+    monkeypatch.setattr(
+        redis_factory,
+        "asyncio",
+        _AsyncioProxy(fake_sleep),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        redis_factory,
+        "random",
+        _RandomProxy(fake_uniform),
+        raising=False,
+    )
+
+    class FailingRedis:
+        def __init__(self) -> None:
+            self.ping_calls = 0
+
+        async def ping(self) -> None:
+            self.ping_calls += 1
+            raise RuntimeError("redis down")
+
+        async def close(self) -> None:  # pragma: no cover - cleanup hook
+            return None
+
+    def fake_from_url(*_args, **_kwargs) -> FailingRedis:
+        return FailingRedis()
+
+    stub_logger = _StubLogger()
+    monkeypatch.setattr(redis_factory, "from_url", fake_from_url)
+    monkeypatch.setattr(redis_factory, "logger", stub_logger)
+
+    factory = redis_factory.RedisFactory(
+        url="redis://user:secret@localhost:6379/1",
+        max_retries=2,
+        base_delay=0.1,
+        max_delay=0.5,
+        jitter=0.0,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await factory.get_client()
+
+    message = str(excinfo.value).lower()
+    assert "max" in message and "retry" in message
+    assert len(sleep_calls) == 2
+
+    for record in stub_logger.records:
+        if record.get("type") == "bind" and "url" in record["kwargs"]:
+            masked_url = str(record["kwargs"]["url"])
+            assert "***" in masked_url
+            assert "secret" not in masked_url
+        if record.get("level") == "warning":
+            formatted = record["message"]
+            if record["args"]:
+                formatted = formatted % record["args"]
+            assert "***" in formatted
+            assert "secret" not in formatted

--- a/workers/redis_factory.py
+++ b/workers/redis_factory.py
@@ -6,6 +6,8 @@
 """
 from __future__ import annotations
 
+import asyncio
+import random
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -35,15 +37,42 @@ def _mask(url: str) -> str:
 class RedisFactory:
     """Factory providing shared Redis client instances for workers."""
 
-    def __init__(self, *, url: str | None = None, client: Redis | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        url: str | None = None,
+        client: Redis | None = None,
+        max_retries: int = 3,
+        base_delay: float = 0.1,
+        max_delay: float = 1.0,
+        jitter: float = 0.05,
+    ) -> None:
         self._configured_url = url
         self._client: Redis | None = client
+        self._max_retries = max(0, int(max_retries))
+        self._base_delay = max(0.0, float(base_delay))
+        self._max_delay = (
+            max(self._base_delay, float(max_delay))
+            if max_delay is not None
+            else self._base_delay
+        )
+        self._jitter = max(0.0, float(jitter))
 
     def _url(self) -> str:
         if self._configured_url is not None:
             return self._configured_url
         settings = get_settings()
         return settings.REDIS_URL
+
+    async def _sleep_with_backoff(self, attempt: int) -> None:
+        if self._base_delay <= 0:
+            return
+        delay = self._base_delay * (2 ** (attempt - 1))
+        delay = min(delay, self._max_delay)
+        if self._jitter > 0:
+            delay += random.uniform(0.0, self._jitter)
+        if delay > 0:
+            await asyncio.sleep(delay)
 
     async def get_client(self) -> Redis | None:
         if self._client is not None:
@@ -52,15 +81,34 @@ class RedisFactory:
             logger.warning("redis.asyncio module unavailable; skipping Redis connection")
             return None
         url = self._url()
-        try:
-            client = from_url(url, encoding="utf-8", decode_responses=True)
-            await client.ping()
-        except Exception as exc:
-            logger.warning("Redis connection failed for %s: %s", _mask(url), exc)
-            return None
-        logger.debug("Redis connection initialised for %s", _mask(url))
-        self._client = client
-        return self._client
+        masked_url = _mask(url)
+        attempt = 0
+        while True:
+            client: Redis | None = None
+            try:
+                client = from_url(url, encoding="utf-8", decode_responses=True)
+                await client.ping()
+            except Exception as exc:  # pragma: no cover - network dependency in tests
+                if client is not None:
+                    try:
+                        await client.close()
+                    except Exception as close_exc:  # pragma: no cover - defensive cleanup
+                        logger.debug("Redis client close failed: %s", close_exc)
+                logger.bind(event="redis.connect", url=masked_url, attempt=attempt + 1).warning(
+                    "Redis connection failed for %s: %s",
+                    masked_url,
+                    exc,
+                )
+                if attempt >= self._max_retries:
+                    raise RuntimeError(
+                        f"Redis connection failed after max retry attempts ({self._max_retries})"
+                    ) from exc
+                attempt += 1
+                await self._sleep_with_backoff(attempt)
+                continue
+            self._client = client
+            logger.debug("Redis connection initialised for %s", masked_url)
+            return self._client
 
     @asynccontextmanager
     async def client(self) -> AsyncIterator[Redis | None]:


### PR DESCRIPTION
## Summary
- add configurable retry and jittered backoff handling to `workers.RedisFactory`
- cover successful retry and masked failure flows in `tests/database/test_redis_factory_backoff.py`
- record the task in the changelog and task tracker documentation

## Testing
- pytest tests/database/test_redis_factory_backoff.py

------
https://chatgpt.com/codex/tasks/task_e_68d0ded723d4832eaad5aa4aa85a6022