### PR TITLE
Amvera: initial deployment support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,13 @@ SPORTMONKS_API_KEY=""
 SPORTMONKS_STUB=1
 ODDS_API_KEY=""
 DATABASE_URL=postgresql+asyncpg://user:pass@postgres:5432/sports
+DATA_ROOT=/data
+DB_PATH=/data/bot.sqlite3
+REPORTS_DIR=/data/reports
+MODEL_REGISTRY_PATH=/data/artifacts
+LOG_DIR=/data/logs
+PYTHONUNBUFFERED=1
+BOT_STARTUP_DELAY=2.5
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_DB=0
@@ -28,7 +35,6 @@ RATE_LIMIT_REQUESTS=60
 RATE_LIMIT_PER_SECONDS=60
 
 # ML / Retrain
-MODEL_REGISTRY_PATH=artifacts/
 RETRAIN_CRON=""
 SEASON_ID=23855  # default season for training script
 SIM_RHO=0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,33 @@ jobs:
             reports/rc_summary.json
             reports/coverage_summary.json
           retention-days: 14
+
+  amvera-smoke:
+    name: amvera-smoke
+    runs-on: ubuntu-latest
+    needs: pipeline
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+
+      - name: Smoke dry-run
+        env:
+          DB_PATH: ${{ runner.temp }}/amvera/bot.sqlite3
+          REPORTS_DIR: ${{ runner.temp }}/amvera/reports
+          LOG_DIR: ${{ runner.temp }}/amvera/logs
+          MODEL_REGISTRY_PATH: ${{ runner.temp }}/amvera/artifacts
+          PYTHONUNBUFFERED: "1"
+        run: |
+          mkdir -p "$REPORTS_DIR" "$LOG_DIR" "$MODEL_REGISTRY_PATH"
+          python -m main --dry-run

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@ Updated 2025-09-10.
 
 - **app/** – FastAPI application with configuration, middlewares and observability.
 - **services/** – business logic and data processing utilities.
-- **ml/** – machine learning models и `LocalModelRegistry` (артефакты в каталоге `artifacts/` или `MODEL_REGISTRY_PATH`) и prediction pipeline.
+- **ml/** – machine learning models и `LocalModelRegistry` (артефакты по умолчанию в `/data/artifacts` или `MODEL_REGISTRY_PATH`) и prediction pipeline.
 - **tests/** – unit, contract, smoke and end-to-end tests.
 - SportMonks client (`app/integrations/sportmonks_client.py`) переключает заглушку через `SPORTMONKS_STUB`.
 - Observability: Sentry controlled by `SENTRY_ENABLED`; Prometheus `/metrics` expose labels `service`, `env`, `version` (from `GIT_SHA` or `APP_VERSION`). Simulation reports include version info in their headers.
@@ -20,7 +20,7 @@ Updated 2025-09-10.
 
 PredictionPipeline сначала вычисляет базовые λ, затем применяет модификаторы
 и получает λ_final. На этом этапе рассчитываются метрики `glm_base_*` и
-`glm_mod_final_*`, результаты сохраняются в `reports/metrics/` и логируются
+`glm_mod_final_*`, результаты сохраняются в `$REPORTS_DIR/metrics/` и логируются
 с тегами `service/env/version/season/modifiers_applied` для последующего
 наблюдения.
 
@@ -42,7 +42,7 @@ Parameters are configurable via `SIM_RHO`, `SIM_N`, `SIM_CHUNK`.
 
 `storage/persistence.py` provides `SQLitePredictionsStore` writing probabilities
 to table `predictions(match_id, market, selection, prob, ts, season, extra)`
-with SQLite fallback (`PREDICTIONS_DB_URL`).
+with SQLite fallback (`DB_PATH`, default `/data/bot.sqlite3`).
 
 ## CLI retrain
 
@@ -55,4 +55,4 @@ with SQLite fallback (`PREDICTIONS_DB_URL`).
   `workers.retrain_scheduler.schedule_retrain`;
 - `status` — выводит список зарегистрированных задач и счётчик `jobs_registered_total`.
 
-Модели и отчёты CLI живут в `artifacts/<SEASON_ID>/` и `reports/metrics/`.
+Модели и отчёты CLI живут в `/data/artifacts/<SEASON_ID>/` и `$REPORTS_DIR/metrics/`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) and `docs/Project.md` for more details.
 
 ## Деплой на Amvera
 
+Полная процедура и чек-листы описаны в [docs/deploy-amvera.md](docs/deploy-amvera.md).
+
 ### Git-поток
 
 ```bash
@@ -34,23 +36,34 @@ git remote add amvera ssh://git@amvera.example.com/telegram-bot.git
 git push amvera main
 ```
 
-### Обязательные переменные окружения
+### Переменные окружения
 
-- `DATABASE_URL` — асинхронный DSN записи (PostgreSQL, `postgresql+asyncpg://`).
-- `DATABASE_URL_RO` — необязательный DSN чтения (RO endpoint, если доступен).
-- `DATABASE_URL_R` — необязательный DSN реплики (fallback для чтения).
-- `REDIS_URL` — строка подключения к управляемому Redis на Amvera.
-- `TELEGRAM_BOT_TOKEN` — токен бота из BotFather.
-- `APP_VERSION` — версия релиза для меток образа и логов.
-- `GIT_SHA` — commit SHA для трассировки (отдаётся в метриках и логах).
+Переменные задаются в разделе «Переменные» Amvera (на сборке недоступны):
 
-### Prestart и health-check
+- `TELEGRAM_BOT_TOKEN` — токен из BotFather (обязательный).
+- `DATABASE_URL` / `DATABASE_URL_RO` / `DATABASE_URL_R` — Postgres DSN для записи и чтения.
+- `REDIS_URL` — URL управляемого Redis (опционально).
+- `DB_PATH` — путь к SQLite-фолбэку (по умолчанию `/data/bot.sqlite3`).
+- `MODEL_REGISTRY_PATH` — каталог артефактов моделей (по умолчанию `/data/artifacts`).
+- `REPORTS_DIR` — каталог отчётов и Markdown-снимков (по умолчанию `/data/reports`).
+- `LOG_DIR` — каталог JSON-логов (по умолчанию `/data/logs`).
+- `BOT_STARTUP_DELAY` — задержка перед запуском long polling (секунды, защита от «double getUpdates»).
+- `PYTHONUNBUFFERED=1` — отключает буферизацию stdout/stderr.
+- `APP_VERSION` и `GIT_SHA` — метки релиза и коммита для логов/метрик.
 
-Entrypoint `scripts/entrypoint.sh` проверяет обязательные переменные, запускает `alembic upgrade head` в асинхронном окружении и маскирует DSN через `mask_dsn()`. После миграций выполняются health-check'и: `DBRouter` опрашивает writer/reader (если заданы `DATABASE_URL_RO`/`DATABASE_URL_R`), а `RedisFactory.health_check()` выполняет `PING` и валидирует доступность Redis. Любой сбой приводит к завершению с кодом `>0`.
+### Хранилище
 
-### Старт процесса
+Amvera монтирует постоянный том в `/data`. Все изменяемые файлы (SQLite, отчёты, артефакты моделей, логи) сохраняются в этом каталоге, код и артефакты сборки остаются неизменными.
 
-При успешном prestart скрипт логирует структурные сообщения и выполняет `python -m main`, что запускает Telegram-бота. Повторный старт контейнера произойдёт автоматически, если миграции или health-check не прошли (код выхода ненулевой).
+### Запуск и smoke
+
+`amvera.yaml` запускает `python main.py`. Скрипт поддерживает `--dry-run` для дымового теста:
+
+```bash
+python -m main --dry-run
+```
+
+Команда выполняет инициализацию зависимостей (кэш, загрузка рейтингов) и завершает процесс без запуска long polling — используется в CI и при проверке конфигурации. Основной режим запускает Aiogram-поллинг после задержки `BOT_STARTUP_DELAY`.
 
 ## Команды бота и примеры
 
@@ -91,7 +104,8 @@ CLI example:
 
 ```bash
 python scripts/run_simulation.py --season-id default --home H --away A --rho 0.1 \
-    --n-sims 10000 --calibrate --write-db --report-md reports/metrics/ECE_simulation_default_H_vs_A.md
+    --n-sims 10000 --calibrate --write-db \
+    --report-md "$REPORTS_DIR/metrics/ECE_simulation_default_H_vs_A.md"
 ```
 
 ## ML-ядро и инварианты
@@ -105,9 +119,9 @@ python scripts/run_simulation.py --season-id default --home H --away A --rho 0.1
 
 Predictions are stored via SQLite fallback (`storage/persistence.py`).
 Table `predictions(match_id, market, selection, prob, ts, season, extra)`.
-DB path is taken from `PREDICTIONS_DB_URL` (defaults to `var/predictions.sqlite`).
+DB path is taken from `DB_PATH` (defaults to `/data/bot.sqlite3`).
 Each pipeline run also writes a Markdown report
-`reports/metrics/SIM_{SEASON}_{home}_vs_{away}.md` with entropy stats.
+`$REPORTS_DIR/metrics/SIM_{SEASON}_{home}_vs_{away}.md` (defaults to `/data/reports/metrics/...`) with entropy stats.
 Control parameters via environment variables:
 
 - `SIM_RHO` – correlation coefficient (default `0.1`)
@@ -131,7 +145,7 @@ Control parameters via environment variables:
 ## Local model registry
 
 `app/ml/model_registry.py` сохраняет модели на файловой системе. По умолчанию используется каталог
-`artifacts/`, который можно переопределить переменной окружения `MODEL_REGISTRY_PATH`.
+`/data/artifacts`, который можно переопределить переменной окружения `MODEL_REGISTRY_PATH`.
 
 ## SportMonks stub mode
 
@@ -143,7 +157,12 @@ Control parameters via environment variables:
 - `TELEGRAM_BOT_TOKEN` — токен Telegram-бота.
 - `SPORTMONKS_API_KEY` — ключ API SportMonks.
 - `SPORTMONKS_STUB` — `1` включает заглушечные ответы SportMonks.
-- `MODEL_REGISTRY_PATH` — каталог LocalModelRegistry (по умолчанию `artifacts/`).
+- `MODEL_REGISTRY_PATH` — каталог LocalModelRegistry (по умолчанию `/data/artifacts`).
+- `REPORTS_DIR` — каталог для Markdown отчётов и снимков CI (по умолчанию `/data/reports`).
+- `LOG_DIR` — каталог JSON-логов приложения (по умолчанию `/data/logs`).
+- `DB_PATH` — путь к SQLite-фолбэку для симуляций (по умолчанию `/data/bot.sqlite3`).
+- `BOT_STARTUP_DELAY` — задержка перед запуском long polling (секунды, по умолчанию `2.5`).
+- `PYTHONUNBUFFERED` — установите `1`, чтобы логи писались без буферизации в контейнере.
 - `RETRAIN_CRON` — crontab для планировщика (пусто/`off` выключает).
 - `SEASON_ID` — сезон для скрипта обучения (по умолчанию `23855`).
 - `SIM_RHO`, `SIM_N`, `SIM_CHUNK` — параметры симуляции (корреляция, число прогонов и размер чанка).
@@ -161,7 +180,7 @@ python scripts/validate_modifiers.py --season-id 23855 --input data/val.csv --al
 - `logloss` — средний отрицательный логарифм правдоподобия Пуассона;
 - `ece` — калибровка по вероятности события (0–1).
 
-Отчёт сохраняется в `reports/metrics/MODIFIERS_<SEASON>.md`.
+Отчёт сохраняется в `$REPORTS_DIR/metrics/MODIFIERS_<SEASON>.md` (по умолчанию `/data/reports/metrics/...`).
 Порог `--tol` (для logloss) и `--tol-ece` задаёт допустимое ухудшение.
 
 ## CI numeric enforcement (modifiers)
@@ -193,9 +212,9 @@ GitHub Actions запускает единый job `pipeline` со стадия�
 - `make test-smoke` — только smoke-маршруты бота (`pytest -q -m bot_smoke`);
 - `make coverage-html` — полный pytest с coverage, HTML-отчётом и жёсткими порогами (`≥80%` total, `≥90%` для `workers/`, `database/`, `services/`, `core/services/`).
 
-Coverage валидируется скриптом `python -m tools.coverage_enforce`, который читает `coverage.xml`, проверяет пороги (≥80% total и ≥90% для `workers/`, `database/`, `services/`, `core/services/`) и обновляет `reports/coverage_summary.json`.
+Coverage валидируется скриптом `python -m tools.coverage_enforce`, который читает `coverage.xml`, проверяет пороги (≥80% total и ≥90% для `workers/`, `database/`, `services/`, `core/services/`) и обновляет `$REPORTS_DIR/coverage_summary.json`.
 Конфигурация `.coveragerc` исключает миграции, shell-скрипты, тесты, документацию и `__init__.py` без логики, чтобы в отчёт попадал только исполняемый код.
-На этапе `reports` формируются артефакты `reports/bot_e2e_snapshot.md` (детерминированные ответы `/help`, `/model`, `/today`, `/match`, `/predict`) и `reports/rc_summary.json`
+На этапе `reports` формируются артефакты `$REPORTS_DIR/bot_e2e_snapshot.md` (детерминированные ответы `/help`, `/model`, `/today`, `/match`, `/predict`) и `$REPORTS_DIR/rc_summary.json`
 с полями `app_version`, `git_sha`, `tests_passed`, `coverage_total`, `coverage_critical_packages`, `docker_image_size_mb`, `timestamp_utc`.
 Финальный шаг публикует артефакт **coverage-and-reports** с HTML-покрытием (`htmlcov/index.html`) и новыми отчётами.
 
@@ -259,10 +278,10 @@ python scripts/cli.py retrain schedule --cron "0 4 * * *"
 python scripts/cli.py retrain status
 ```
 
-Артефакты сохраняются в `artifacts/<SEASON_ID>/` через `LocalModelRegistry`: `glm_home.pkl`,
+Артефакты сохраняются в `/data/artifacts/<SEASON_ID>/` через `LocalModelRegistry`: `glm_home.pkl`,
 `glm_away.pkl`, `model_info.json` и (при флаге `--with-modifiers`) `modifiers_model.pkl`.
-Метрики `logloss`/`ece` модификаторов записываются в `reports/metrics/MODIFIERS_<SEASON>.md`,
-а краткий итог добавляется в `reports/RUN_SUMMARY.md`.
+Метрики `logloss`/`ece` модификаторов записываются в `$REPORTS_DIR/metrics/MODIFIERS_<SEASON>.md`,
+а краткий итог добавляется в `$REPORTS_DIR/RUN_SUMMARY.md`.
 
 ## Smart pre-commit fallback
 

--- a/amvera.yaml
+++ b/amvera.yaml
@@ -1,0 +1,15 @@
+# @file: amvera.yaml
+# @description: Deployment configuration for Amvera platform
+# @dependencies: requirements.txt, main.py
+# @created: 2025-10-03
+meta:
+  environment: python
+  toolchain:
+    name: pip
+    version: 3.11
+build:
+  requirementsPath: requirements.txt
+run:
+  scriptName: main.py
+  persistenceMount: /data
+  containerPort: 80

--- a/app/ml/model_registry.py
+++ b/app/ml/model_registry.py
@@ -18,7 +18,12 @@ class LocalModelRegistry:
     """Persist and load models from the filesystem."""
 
     def __init__(self, base_dir: str | Path | None = None) -> None:
-        self.base_dir = Path(base_dir or os.getenv("MODEL_REGISTRY_PATH", "artifacts"))
+        data_root = Path(os.getenv("DATA_ROOT", "/data"))
+        default_dir = Path(os.getenv("MODEL_REGISTRY_PATH", str(data_root / "artifacts")))
+        base_path = Path(base_dir) if base_dir else default_dir
+        if not base_path.is_absolute():
+            base_path = data_root / base_path
+        self.base_dir = base_path
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
     def _model_path(self, name: str, season: int | str | None = None) -> Path:

--- a/docs/Project.md
+++ b/docs/Project.md
@@ -124,7 +124,7 @@ Rolling/walk-forward CV; LogLoss, Brier, ECE.
 Мониторинг: Prometheus (pred_total, prob_bins, rolling_ece, rolling_logloss) и Sentry.
 PredictionPipeline дополнительно записывает `glm_base_*` и `glm_mod_final_*`
 с тегами `service/env/version/season/modifiers_applied` и формирует
-markdown-отчёт `reports/metrics/MODIFIERS_<season>.md`.
+markdown-отчёт `$REPORTS_DIR/metrics/MODIFIERS_<season>.md` (по умолчанию `/data/reports/metrics/...`).
 Недельные отчёты.
 
 ## 7. Безопасность

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,17 @@
+## [2025-10-03] - Amvera deployment support
+### Добавлено
+- Конфигурация `amvera.yaml` для окружения Python/pip 3.11 с точкой входа `main.py` и монтированием `/data`.
+- Документ [docs/deploy-amvera.md](deploy-amvera.md) с инструкциями по перемещению SQLite, smoke-проверкам и сценариям доставки.
+- Джоб GitHub Actions `amvera-smoke`, запускающий `python -m main --dry-run` с временными путями `/data`.
+
+### Изменено
+- Путь всех изменяемых данных (SQLite, отчёты, артефакты, логи) переведён на конфигурируемые переменные (`DB_PATH`, `REPORTS_DIR`, `MODEL_REGISTRY_PATH`, `LOG_DIR`) с дефолтом `/data/...`.
+- `main.py` и `telegram/bot.py` поддерживают флаг `--dry-run` и задержку `BOT_STARTUP_DELAY` перед long polling.
+- README и `.env.example` актуализированы под требования Amvera (PYTHONUNBUFFERED, новые ENV, использование `/data`).
+
+### Исправлено
+- Исключены записи в репозиторий при генерации отчётов/логов: все пути создаются в `/data`, что устраняет ошибки `sqlite is readonly`.
+
 ## [2025-10-02] - E6.18: Prediction worker dirty payload coverage
 ### Добавлено
 - Параметризованные тесты `tests/workers/test_prediction_worker_errors.py` проверяют ошибки ядра,

--- a/docs/deploy-amvera.md
+++ b/docs/deploy-amvera.md
@@ -1,0 +1,104 @@
+<!--
+@file: docs/deploy-amvera.md
+@description: Amvera deployment guide for Telegram bot
+@dependencies: README.md, amvera.yaml
+@created: 2025-10-03
+-->
+
+# Руководство по деплою на Amvera
+
+## 1. Требования платформы
+- **amvera.yaml** описывает окружение `python/pip 3.11`, точку входа `main.py`, монтирование `/data`.
+- Все изменяемые данные (`DB_PATH`, `MODEL_REGISTRY_PATH`, `REPORTS_DIR`, `LOG_DIR`) должны находиться под `/data`.
+- Переменные окружения и секреты задаются в UI Amvera; во время сборки недоступны.
+- Для Telegram long polling добавлена задержка `BOT_STARTUP_DELAY` (2.5 c) и флаг `--dry-run` для smoke.
+- Логи должны идти без буферизации (`PYTHONUNBUFFERED=1`).
+- Серверное время — UTC; конвертацию делайте в клиенте/репортах при необходимости.
+
+## 2. Обязательные переменные окружения
+| Переменная | Назначение | Значение по умолчанию |
+| --- | --- | --- |
+| `TELEGRAM_BOT_TOKEN` | Токен бота из BotFather | — (обязателен) |
+| `DATABASE_URL` | Async DSN writer (Postgres) | — |
+| `DATABASE_URL_RO` | Async DSN чтения (опционально) | — |
+| `DATABASE_URL_R` | DSN реплики (опционально) | — |
+| `REDIS_URL` | Redis в Amvera (если используется) | — |
+| `DB_PATH` | SQLite fallback | `/data/bot.sqlite3` |
+| `MODEL_REGISTRY_PATH` | Каталог артефактов моделей | `/data/artifacts` |
+| `REPORTS_DIR` | Каталог отчётов и markdown | `/data/reports` |
+| `LOG_DIR` | Каталог JSON-логов | `/data/logs` |
+| `BOT_STARTUP_DELAY` | Задержка перед polling (секунды) | `2.5` |
+| `PYTHONUNBUFFERED` | Небуферизованные логи | `1` |
+| `APP_VERSION` | Версия релиза | — |
+| `GIT_SHA` | Commit SHA | — |
+
+## 3. Подготовка окружения
+1. Создайте приложение на Amvera и смонтируйте persistence (по умолчанию `/data`).
+2. Заполните переменные окружения по таблице выше.
+3. Убедитесь, что директория `/data` пуста либо содержит мигрированные данные SQLite (см. раздел 5).
+4. При необходимости загрузите модели/отчёты в каталог `/data/artifacts` через вкладку **Repository → Data**.
+
+## 4. CI и smoke-проверка
+- GitHub Actions содержит job `amvera-smoke`, который выполняет `python -m main --dry-run` c временным `DB_PATH`/`REPORTS_DIR`.
+- Локально перед деплоем выполните:
+  ```bash
+  export DB_PATH=$(mktemp -u)
+  export REPORTS_DIR=$(mktemp -d)
+  export PYTHONUNBUFFERED=1
+  python -m main --dry-run
+  ```
+  Команда проверит инициализацию зависимостей без запуска polling.
+
+## 5. Перенос существующей SQLite
+1. На старом окружении остановите бота и убедитесь, что SQLite не меняется.
+2. Скопируйте файл в безопасное место: `scp bot.sqlite3 ops@host:/tmp/bot.sqlite3`.
+3. В Amvera откройте **Repository → Data**, создайте каталог `data` (если нет) и загрузите файл как `bot.sqlite3`.
+4. Проверьте права доступа: файл должен принадлежать пользователю приложения и находиться по пути `/data/bot.sqlite3`.
+5. Обновите переменную `DB_PATH`, если имя файла отличается.
+
+## 6. Сценарии доставки кода
+### 6.1 Git push в репозиторий Amvera
+1. Добавьте удалённый репозиторий: `git remote add amvera ssh://git@amvera.example.com/telegram-bot.git`.
+2. Выполните `git push amvera main` (или выбранную ветку). Платформа автоматически запустит сборку и деплой.
+
+### 6.2 Вебхук из GitHub/GitLab
+1. Создайте персональный токен в Amvera (раздел Integrations → Webhooks).
+2. Настройте webhook на стороне GitHub/GitLab на событие `push` (или `workflow_run` после успешного CI).
+3. Укажите endpoint из Amvera, добавьте токен в заголовок `X-Amvera-Token`.
+4. Проверьте, что webhook триггерит сборку и отображается в журнале.
+
+## 7. Процесс деплоя
+1. Обновите `main` (или release-ветку) через PR, дождитесь зелёного CI (lint, tests, `amvera-smoke`).
+2. Выполните git push или дождитесь webhook-а (раздел 6).
+3. В Amvera мониторьте логи сборки; убедитесь, что `pip install` завершился успешно.
+4. После старта контейнера проверьте логи приложения (`/data/logs/app_*.json.log`).
+5. Запустите smoke-команду в контейнере при необходимости: `python -m main --dry-run`.
+6. Выполните ручной тест бота (команды `/start`, `/predict`).
+
+## 8. Откат и пересборка
+- Для отката выберите предыдущий билд в интерфейсе Amvera и нажмите **Rollback**.
+- При пересборке без изменения кода выполните `git commit --allow-empty -m "chore: rebuild"` и push, либо перезапустите билд в UI.
+- При сбоях удаления данных: восстановите `/data` из резервной копии (см. раздел 5) и перезапустите контейнер.
+
+## 9. Типовые ошибки и диагностика
+| Симптом | Причина | Диагностика |
+| --- | --- | --- |
+| `double getUpdates` / бот отключается | Несколько инстансов без задержки | Убедитесь, что `BOT_STARTUP_DELAY` > 0 и только один контейнер активен. |
+| `sqlite is readonly` | Файл находится вне `/data` | Проверьте переменную `DB_PATH`, права и расположение файла. |
+| Нет логов в UI | Отсутствует `PYTHONUNBUFFERED` | Установите переменную в окружении и перезапустите контейнер. |
+| Ошибки Redis | `REDIS_URL` не задан или неверный | Проверьте переменную в UI, выполните `redis-cli PING` из контейнера. |
+| `TELEGRAM_BOT_TOKEN` отсутствует | Бот завершается сразу | Заполните переменную и перезапустите приложение. |
+
+См. официальные руководства Amvera:
+- [docs.amvera.ru/platform/storage](https://docs.amvera.ru/platform/storage)
+- [docs.amvera.ru/platform/variables](https://docs.amvera.ru/platform/variables)
+- [docs.amvera.ru/platform/telegram-bot](https://docs.amvera.ru/platform/telegram-bot)
+- [docs.amvera.ru/platform/sqlite](https://docs.amvera.ru/platform/sqlite)
+
+## 10. Чек-лист релиз-менеджера
+- [ ] SQLite перенесена в `/data` и указана в `DB_PATH`.
+- [ ] Переменные окружения актуализированы (см. таблицу).
+- [ ] Выполнен `python -m main --dry-run` (локально и в CI).
+- [ ] Проверены логи `/data/logs`. Убедиться в наличии строк запуска.
+- [ ] Команды `/start`, `/model`, `/predict` отвечают корректно.
+- [ ] Сохранены артефакты моделей `/data/artifacts`.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,13 @@
+## Задача: Amvera — подготовка к деплою
+- **Статус**: В процессе
+- **Описание**: Перевести бот на требования Amvera: хранить данные в `/data`, добавить `amvera.yaml`, smoke-проверку и документацию.
+- **Шаги выполнения**:
+  - [x] Обновлены настройки и код для чтения путей из `DB_PATH`/`REPORTS_DIR`/`MODEL_REGISTRY_PATH`/`LOG_DIR` с дефолтом `/data`.
+  - [x] Добавлен `--dry-run` и задержка `BOT_STARTUP_DELAY` перед запуском polling.
+  - [x] Добавлены `amvera.yaml`, документация и GitHub Actions job `amvera-smoke`.
+  - [ ] Выполнить деплой на Amvera и smoke-проверку в боевом окружении.
+- **Зависимости**: amvera.yaml, README.md, docs/deploy-amvera.md, main.py, telegram/bot.py, storage/persistence.py, .github/workflows/ci.yml
+
 ## Задача: E6.18 — Prediction worker dirty payload coverage
 - **Статус**: Завершена
 - **Описание**: Расширить негативные тесты воркера предсказаний: маскирование ошибок ядра, таймаут Redis-lock и валидацию «грязного» payload (NaN/negative).

--- a/logger.py
+++ b/logger.py
@@ -12,8 +12,8 @@ from loguru import logger
 from config import settings
 
 # Создаем директорию для логов если её нет
-log_dir = Path("logs")
-log_dir.mkdir(exist_ok=True)
+log_dir = Path(settings.LOG_DIR)
+log_dir.mkdir(parents=True, exist_ok=True)
 
 # Глобальная переменная для отслеживания деградации модели
 _model_degradation_threshold = 0.1  # Порог деградации 10%

--- a/reports/bot_e2e_snapshot.py
+++ b/reports/bot_e2e_snapshot.py
@@ -31,7 +31,9 @@ from telegram.handlers import predict as predict_handler  # noqa: E402
 from telegram.handlers import today as today_handler  # noqa: E402
 
 SNAPSHOT_SEED = 20240922
-SNAPSHOT_PATH = Path("reports/bot_e2e_snapshot.md")
+_DATA_ROOT = Path(os.getenv("DATA_ROOT", "/data"))
+_REPORTS_ROOT = Path(os.getenv("REPORTS_DIR", str(_DATA_ROOT / "reports")))
+SNAPSHOT_PATH = _REPORTS_ROOT / "bot_e2e_snapshot.md"
 
 
 class SnapshotQueue:

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -71,7 +72,9 @@ def _load_training_frame(season_id: str) -> tuple[pd.DataFrame, str]:
 
 
 def _ensure_artifact_dir(season_id: str) -> Path:
-    path = Path("artifacts") / season_id
+    data_root = Path(os.getenv("DATA_ROOT", "/data"))
+    registry_root = Path(os.getenv("MODEL_REGISTRY_PATH", str(data_root / "artifacts")))
+    path = registry_root / season_id
     path.mkdir(parents=True, exist_ok=True)
     return path
 
@@ -145,7 +148,9 @@ def _train_modifiers_and_metrics(
         f"| ece | {base_ece:.4f} | {final_ece:.4f} | {delta_ece:.4f} |\n"
     )
 
-    report_dir = Path("reports/metrics")
+    data_root = Path(os.getenv("DATA_ROOT", "/data"))
+    reports_root = Path(os.getenv("REPORTS_DIR", str(data_root / "reports")))
+    report_dir = reports_root / "metrics"
     report_dir.mkdir(parents=True, exist_ok=True)
     report_path = report_dir / f"MODIFIERS_{season_id}.md"
     report_path.write_text(table, encoding="utf-8")
@@ -166,7 +171,9 @@ def _train_modifiers_and_metrics(
 
 
 def _update_run_summary(payload: dict[str, Any]) -> None:
-    summary_path = Path("reports/RUN_SUMMARY.md")
+    data_root = Path(os.getenv("DATA_ROOT", "/data"))
+    reports_root = Path(os.getenv("REPORTS_DIR", str(data_root / "reports")))
+    summary_path = reports_root / "RUN_SUMMARY.md"
     lines = [
         "",
         "## CLI retrain",

--- a/scripts/publish_rc_summary.py
+++ b/scripts/publish_rc_summary.py
@@ -5,17 +5,21 @@
 @created: 2025-09-15
 """
 
+import os
 from pathlib import Path
 
 
 def main() -> None:
+    data_root = Path(os.getenv("DATA_ROOT", "/data"))
+    reports_root = Path(os.getenv("REPORTS_DIR", str(data_root / "reports")))
+    registry_root = Path(os.getenv("MODEL_REGISTRY_PATH", str(data_root / "artifacts")))
     changelog = Path("docs/changelog.md").read_text(encoding="utf-8")
-    run_summary = Path("reports/RUN_SUMMARY.md").read_text(encoding="utf-8")
+    run_summary = (reports_root / "RUN_SUMMARY.md").read_text(encoding="utf-8")
     artifacts = (
-        "reports/metrics/**/*.md\n"
-        "reports/metrics/**/*.png\n"
-        "artifacts/**/*\n"
-        "var/predictions.sqlite\n"
+        f"{reports_root}/metrics/**/*.md\n"
+        f"{reports_root}/metrics/**/*.png\n"
+        f"{registry_root}/**/*\n"
+        f"{os.getenv('DB_PATH', str(data_root / 'bot.sqlite3'))}\n"
     )
     content = (
         "# Release Notes RC\n\n"
@@ -23,8 +27,8 @@ def main() -> None:
         "## Run Summary\n" + run_summary + "\n"
         "## Artifacts\n" + artifacts + "\n"
     )
-    Path("reports").mkdir(exist_ok=True)
-    Path("reports/RELEASE_NOTES_RC.md").write_text(content, encoding="utf-8")
+    reports_root.mkdir(parents=True, exist_ok=True)
+    (reports_root / "RELEASE_NOTES_RC.md").write_text(content, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/scripts/train_glm.py
+++ b/scripts/train_glm.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 import sys
 
@@ -78,7 +79,9 @@ def main() -> None:
 
     raw_df = load_dataframe(args.input)
     model_home, model_away, info = train_models(raw_df, args.alpha, args.l2)
-    out_dir = Path("artifacts") / str(args.season_id)
+    data_root = Path(os.getenv("DATA_ROOT", "/data"))
+    registry_root = Path(os.getenv("MODEL_REGISTRY_PATH", str(data_root / "artifacts")))
+    out_dir = registry_root / str(args.season_id)
     out_dir.mkdir(parents=True, exist_ok=True)
     joblib.dump(model_home, out_dir / "glm_home.pkl")
     joblib.dump(model_away, out_dir / "glm_away.pkl")

--- a/scripts/train_modifiers.py
+++ b/scripts/train_modifiers.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 import sys
 
@@ -76,7 +77,9 @@ def main() -> None:
     y_home = np.log(targets["target_home"].astype(float)) - np.log(targets["lambda_home"].astype(float))
     y_away = np.log(targets["target_away"].astype(float)) - np.log(targets["lambda_away"].astype(float))
     model = ModifiersModel(alpha=args.alpha).fit(X, y_home, y_away)
-    out_dir = Path("artifacts") / str(args.season_id)
+    data_root = Path(os.getenv("DATA_ROOT", "/data"))
+    registry_root = Path(os.getenv("MODEL_REGISTRY_PATH", str(data_root / "artifacts")))
+    out_dir = registry_root / str(args.season_id)
     out_dir.mkdir(parents=True, exist_ok=True)
     model.save(out_dir / "modifiers_model.pkl")
 

--- a/scripts/validate_modifiers.py
+++ b/scripts/validate_modifiers.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -68,7 +69,9 @@ def main() -> int:
         f"| ece | {base_ece:.4f} | {final_ece:.4f} | {delta_ece:.4f} |\n"
     )
     print(table)
-    report_dir = Path("reports/metrics")
+    data_root = Path(os.getenv("DATA_ROOT", "/data"))
+    reports_root = Path(os.getenv("REPORTS_DIR", str(data_root / "reports")))
+    report_dir = reports_root / "metrics"
     report_dir.mkdir(parents=True, exist_ok=True)
     report_path = report_dir / f"MODIFIERS_{args.season_id}.md"
     report_path.write_text(table)

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1,6 +1,7 @@
 # telegram/bot.py
 # Логика Telegram-бота: инициализация, обработчики, запуск polling.
 import asyncio
+import os
 import signal
 
 from aiogram import Bot, Dispatcher
@@ -158,14 +159,27 @@ class TelegramBot:
         if hasattr(signal, "SIGBREAK"):
             signal.signal(signal.SIGBREAK, self._signal_handler)
 
-    async def run(self):
+    async def run(self, dry_run: bool = False):
         """Запуск бота с обработкой ошибок."""
         try:
+            delay_raw = os.getenv("BOT_STARTUP_DELAY", "2.5")
+            try:
+                delay = max(0.0, float(delay_raw))
+            except ValueError:
+                delay = 2.5
+            if delay:
+                logger.info(f"⏳ Ожидание перед инициализацией бота {delay:.2f} c")
+                await asyncio.sleep(delay)
             # Инициализация
             await self.initialize()
 
             if not self.bot or not self.dp:
                 raise RuntimeError("Бот не инициализирован")
+
+            if dry_run:
+                logger.info("🚦 Dry-run: пропуск запуска polling")
+                await self.cleanup()
+                return
 
             # Настройка обработчиков сигналов
             self._setup_signal_handlers()
@@ -252,16 +266,16 @@ async def get_bot() -> TelegramBot:
     return _bot_instance
 
 
-async def main():
+async def main(dry_run: bool = False):
     """Асинхронная точка входа для бота."""
     bot = await get_bot()
-    await bot.run()
+    await bot.run(dry_run=dry_run)
 
 
 # Альтернативная функция для использования в других модулях
-async def start_bot():
+async def start_bot(dry_run: bool = False):
     """Запуск бота (альтернативный способ)."""
-    await main()
+    await main(dry_run=dry_run)
 
 
 # Экспорт класса и функций

--- a/tests/integration/test_pipeline_writes_markets.py
+++ b/tests/integration/test_pipeline_writes_markets.py
@@ -23,7 +23,9 @@ def test_pipeline_writes_markets(tmp_path, monkeypatch):
         def transform(self, df: pd.DataFrame) -> pd.DataFrame:  # noqa: D401
             return df
 
-    monkeypatch.setenv("PREDICTIONS_DB_URL", str(tmp_path / "pred.sqlite"))
+    monkeypatch.setenv("DB_PATH", str(tmp_path / "pred.sqlite"))
+    reports_dir = tmp_path / "reports"
+    monkeypatch.setenv("REPORTS_DIR", str(reports_dir))
     monkeypatch.setenv("SIM_N", "512")
     reset_settings_cache()
 
@@ -67,7 +69,7 @@ def test_pipeline_writes_markets(tmp_path, monkeypatch):
     sum_cs = sum(prob for m, _, prob in rows if m == "cs")
     assert pytest.approx(1.0, rel=1e-2) == sum_cs
 
-    report = Path("reports/metrics/SIM_S_H_vs_A.md")
+    report = reports_dir / "metrics" / "SIM_S_H_vs_A.md"
     assert report.exists()
     content = report.read_text(encoding="utf-8")
     assert "### Entropy" in content

--- a/tests/smoke/test_cli_retrain.py
+++ b/tests/smoke/test_cli_retrain.py
@@ -28,19 +28,28 @@ def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_cli_retrain_run_and_schedule(monkeypatch):
+def test_cli_retrain_run_and_schedule(monkeypatch, tmp_path):
     runtime_scheduler.clear_jobs()
     monkeypatch.delenv("RETRAIN_CRON", raising=False)
 
     repo_root = Path(__file__).resolve().parents[2]
-    artifacts_dir = repo_root / "artifacts" / "default"
+    registry_root = tmp_path / "artifacts"
+    reports_root = tmp_path / "reports"
+    logs_root = tmp_path / "logs"
+    db_path = tmp_path / "bot.sqlite3"
+    monkeypatch.setenv("MODEL_REGISTRY_PATH", str(registry_root))
+    monkeypatch.setenv("REPORTS_DIR", str(reports_root))
+    monkeypatch.setenv("LOG_DIR", str(logs_root))
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    artifacts_dir = registry_root / "default"
     if artifacts_dir.exists():
         shutil.rmtree(artifacts_dir)
-    metrics_report = repo_root / "reports" / "metrics" / "MODIFIERS_default.md"
+    metrics_report = reports_root / "metrics" / "MODIFIERS_default.md"
     if metrics_report.exists():
         metrics_report.unlink()
 
-    summary_path = repo_root / "reports" / "RUN_SUMMARY.md"
+    summary_path = reports_root / "RUN_SUMMARY.md"
     summary_before = summary_path.read_text(encoding="utf-8") if summary_path.exists() else ""
 
     result = _run_cli("retrain", "run", "--season-id", "default", "--with-modifiers")

--- a/tests/smoke/test_run_simulation_cli.py
+++ b/tests/smoke/test_run_simulation_cli.py
@@ -16,7 +16,7 @@ import pytest
 def test_run_simulation_cli(tmp_path: Path):
     db = tmp_path / "preds.sqlite"
     report = tmp_path / "report.md"
-    env = {"PREDICTIONS_DB_URL": str(db)}
+    env = {"DB_PATH": str(db)}
     cmd = [
         "python",
         "scripts/run_simulation.py",

--- a/tests/smoke/test_validate_modifiers_cli.py
+++ b/tests/smoke/test_validate_modifiers_cli.py
@@ -6,6 +6,7 @@
 """
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -13,7 +14,8 @@ from pathlib import Path
 def test_validate_modifiers_cli(tmp_path: Path) -> None:
     data = tmp_path / "val.csv"
     data.write_text("lambda_home,lambda_away,home_goals,away_goals\n1,1,0,0\n")
-    report = Path("reports/metrics/MODIFIERS_test.md")
+    reports_root = tmp_path / "reports"
+    report = reports_root / "metrics" / "MODIFIERS_test.md"
     if report.exists():
         report.unlink()
     cmd = [
@@ -28,6 +30,7 @@ def test_validate_modifiers_cli(tmp_path: Path) -> None:
         "--l2",
         "1.0",
     ]
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    env = {**os.environ, "REPORTS_DIR": str(reports_root)}
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
     assert proc.returncode == 0
     assert report.exists()

--- a/workers/runtime_scheduler.py
+++ b/workers/runtime_scheduler.py
@@ -26,7 +26,15 @@ _JOBS_COUNTER = Counter(
     "Total jobs registered",
     ["service", "env", "version"],
 )
-_STATE_FILE = Path(os.getenv("RUNTIME_SCHEDULER_STATE", "artifacts/runtime_scheduler_state.json"))
+_DATA_ROOT = Path(os.getenv("DATA_ROOT", "/data"))
+_STATE_ENV = os.getenv("RUNTIME_SCHEDULER_STATE")
+if _STATE_ENV:
+    candidate = Path(_STATE_ENV)
+    if not candidate.is_absolute():
+        candidate = _DATA_ROOT / candidate
+    _STATE_FILE = candidate
+else:
+    _STATE_FILE = _DATA_ROOT / "artifacts/runtime_scheduler_state.json"
 
 
 def _state_payload() -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- add amvera.yaml and comprehensive Amvera deployment guide covering storage, smoke checks and delivery flows
- switch runtime paths for SQLite, artifacts, reports and logs to configurable /data defaults with updated README/.env
- implement main.py/telegram.bot dry-run mode with startup delay and adjust services/tests for new environment variables
- extend CI with amvera-smoke dry-run job and document progress in changelog/tasktracker

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2328618d0832eaf8bac5ea52c6512