### PR TITLE
Add Prometheus alerts configuration and runbook

### DIFF
--- a/.env.alerts.example
+++ b/.env.alerts.example
@@ -1,0 +1,7 @@
+# @file: .env.alerts.example
+# @description: Environment defaults for Prometheus alerts thresholds.
+# @created: 2025-10-29
+
+SM_FRESHNESS_WARN_HOURS=6
+SM_FRESHNESS_FAIL_HOURS=12
+WORKER_DEADMAN_SEC=900

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,10 @@ jobs:
           python -m black --check .
           python -m isort --check-only .
 
+      - name: alerts-validate
+        run: make alerts-validate
+        continue-on-error: true
+
       - name: test-fast
         run: make test-fast
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PRECOMMIT ?= pre-commit
 PRE_COMMIT_HOME ?= .cache/pre-commit
 
 .PHONY: setup deps-fix lint lint-soft lint-strict lint-app lint-changed fmt test test-fast test-smoke test-all coverage-html \
-reports-gaps pre-commit-smart smoke pre-commit-offline check deps-lock deps-sync docker-build docker-run
+reports-gaps pre-commit-smart smoke pre-commit-offline check deps-lock deps-sync docker-build docker-run alerts-validate
 
 IMAGE_NAME ?= telegram-bot
 APP_VERSION ?= 0.0.0
@@ -127,13 +127,16 @@ deps-sync:
 
 docker-build:
 	docker build --build-arg APP_VERSION=$(APP_VERSION) --build-arg GIT_SHA=$(GIT_SHA) \
-	        -t $(IMAGE_NAME):$(IMAGE_TAG) .
+                -t $(IMAGE_NAME):$(IMAGE_TAG) .
 
 docker-run:
 	docker run --rm \
-	        -e DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/app \
-	        -e REDIS_URL=redis://localhost:6379/0 \
-	        -e TELEGRAM_BOT_TOKEN=TEST_TELEGRAM_TOKEN \
-	        -e APP_VERSION=$(APP_VERSION) \
-	        -e GIT_SHA=$(GIT_SHA) \
+	-e DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/app \
+	-e REDIS_URL=redis://localhost:6379/0 \
+	-e TELEGRAM_BOT_TOKEN=TEST_TELEGRAM_TOKEN \
+	-e APP_VERSION=$(APP_VERSION) \
+	-e GIT_SHA=$(GIT_SHA) \
 	$(IMAGE_NAME):$(IMAGE_TAG)
+
+alerts-validate:
+	$(PY) tools/alerts_validate.py

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Telegram bot that exposes a FastAPI service and ML pipeline for football match p
 
 Sentry can be toggled via the `SENTRY_ENABLED` environment variable. Prometheus metrics are exposed on the same HTTP service when `ENABLE_METRICS=1` (see `/metrics`); the optional `METRICS_PORT` remains available for internal scrapes but is not exposed outside the Amvera pod. All metrics include constant labels `service`, `env` and `version` (from `GIT_SHA` or `APP_VERSION`). Markdown reports produced by simulation scripts also embed the version in the header.
 
+### Monitoring & Alerts
+
+- Подключите `monitoring/alerts.yaml` к вашему Prometheus (или `PrometheusRule` в kube-prometheus) через `kubectl apply -f monitoring/alerts.yaml` либо Helm-шаблон с `envsubst` для подстановки порогов.
+- Пороговые значения управляются переменными `SM_FRESHNESS_WARN_HOURS`, `SM_FRESHNESS_FAIL_HOURS` и `WORKER_DEADMAN_SEC` (см. `.env.alerts.example`).
+- Используемые метрики: `sm_freshness_hours_max`, `sm_sync_failures_total`, `worker_refresh_done_timestamp`, `sm_requests_total{component="odds"}`, `sm_matches_open_total`, `app_ready{status="fail"}`.
+- Для оперативных действий при алёртах см. [docs/runbook.md](docs/runbook.md).
+
 ## Reliability v2 badges
 
 - `/value` и `/compare` показывают бейдж `Reliability: csv …, http …` для текущей лиги/рынка и кнопку «Почему этот провайдер?» с расшифровкой fresh/latency/stability/closing из `app.lines.reliability_v2`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,15 @@
+## [2025-10-30] - Monitoring alerts and runbook
+### Добавлено
+- Файл `monitoring/alerts.yaml` с правилами Data Freshness, ETL Failures, Worker Deadman, Odds Pipeline и API Readiness.
+- Пример окружения `.env.alerts.example` с порогами без секретов.
+- Runbook `docs/runbook.md` с действиями по алёртам.
+
+### Изменено
+- README дополнен разделом «Monitoring & Alerts», Makefile включает цель `alerts-validate`, CI добавляет мягкую проверку алёртов.
+
+### Исправлено
+- —
+
 ## [2025-10-29] - Amvera preflight gate
 ### Добавлено
 - Скрипт `scripts/preflight.py` с режимами `strict` и `health` для миграций и health-check перед стартом ролей.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,27 @@
+<!--
+@file: docs/runbook.md
+@description: Operations runbook for monitoring alerts.
+@created: 2025-10-29
+-->
+
+# Monitoring Runbook
+
+## Data Freshness RED
+- Проверить состояние токена и квот SportMonks (панель провайдера, `SPORTMONKS_*` переменные).
+- Изучить логи `sm_sync` / `scripts/sm_sync.py` на признаки таймаутов или rate-limit.
+- Убедиться, что воркер активен, при необходимости перезапустить роль `worker` после устранения причин.
+
+## Worker Deadman
+- Проверить доступность Redis и PostgreSQL, убедиться, что очередь/lock-сервис отвечает.
+- Осмотреть lock-файл `/data/runtime.lock`, удалить, если он stale и процесс не работает.
+- Перезапустить воркер (`python -m scripts.worker` или профиль Amvera) после очистки зависимостей.
+
+## API Readiness 503
+- Убедиться, что `PRESTART_PREFLIGHT=1` и последний прогон preflight завершился успешно.
+- Запросить `/readyz` вручную, изучить подробности ответа (`status`, `checks`).
+- Проверить подключение к PostgreSQL/Redis, восстановить доступность сервисов и перезапустить роль `api`.
+
+## Odds stalled
+- Проверить провайдера котировок и сетевые таймауты в логах `services/odds`.
+- Увеличить `ODDS_TIMEOUT_SEC` или число ретраев, если наблюдаются частые timeouts.
+- Убедиться, что внешние матчи доступны и нет глобального простоя провайдера.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: Мониторинг и runbook для SportMonks/odds
+- **Статус**: Завершена
+- **Описание**: Добавить Prometheus-алёрты, пример переменных и краткий runbook без изменений бизнес-логики.
+- **Шаги выполнения**:
+  - [x] Создан `monitoring/alerts.yaml` с правилами Data Freshness, ETL, Worker Deadman, Odds stalled и API readiness.
+  - [x] Добавлен `.env.alerts.example` с порогами `SM_FRESHNESS_*`, `WORKER_DEADMAN_SEC`.
+  - [x] Обновлены README (Monitoring & Alerts), docs/runbook.md и Makefile/CI (`alerts-validate`).
+- **Зависимости**: monitoring/alerts.yaml, .env.alerts.example, README.md, docs/runbook.md, Makefile, .github/workflows/ci.yml, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: Preflight-гейт для ролей Amvera
 - **Статус**: Завершена
 - **Описание**: Включить опциональный строгий preflight для ролей `api`/`worker` и зафиксировать его в документации.

--- a/monitoring/alerts.yaml
+++ b/monitoring/alerts.yaml
@@ -1,0 +1,90 @@
+# @file: monitoring/alerts.yaml
+# @description: Prometheus alert rules for SportMonks ETL, odds pipeline, and API readiness.
+# @created: 2025-10-29
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: telegram-bot-alerts
+  labels:
+    role: alerts
+spec:
+  groups:
+    - name: sportmonks.data
+      rules:
+        - alert: DataFreshnessCritical
+          expr: sm_freshness_hours_max > ${SM_FRESHNESS_FAIL_HOURS:-12}
+          for: 10m
+          labels:
+            severity: critical
+            service: telegram-bot
+          annotations:
+            summary: "Data freshness degraded"
+            description: |
+              Maximum SportMonks data freshness exceeded ${SM_FRESHNESS_FAIL_HOURS:-12} hours.
+              Check worker logs and SportMonks API quotas.
+        - alert: DataFreshnessWarning
+          expr: sm_freshness_hours_max > ${SM_FRESHNESS_WARN_HOURS:-6}
+          for: 10m
+          labels:
+            severity: warning
+            service: telegram-bot
+          annotations:
+            summary: "Data freshness approaching limit"
+            description: |
+              Maximum SportMonks data freshness exceeded ${SM_FRESHNESS_WARN_HOURS:-6} hours.
+              Review latest sync runs and upcoming fixtures.
+        - alert: EtlFailuresWarning
+          expr: increase(sm_sync_failures_total[30m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+            service: telegram-bot
+          annotations:
+            summary: "SportMonks ETL failures detected"
+            description: |
+              SportMonks sync failures increased within the last 30 minutes.
+              Inspect worker logs and retriable errors.
+    - name: workers.health
+      rules:
+        - alert: WorkerDeadman
+          expr: |
+            absent(worker_refresh_done_timestamp)
+            or (time() - worker_refresh_done_timestamp > ${WORKER_DEADMAN_SEC:-900})
+          for: 0m
+          labels:
+            severity: critical
+            service: telegram-bot
+          annotations:
+            summary: "Worker refresh heartbeat lost"
+            description: |
+              Worker refresh timestamp missing or stale for more than ${WORKER_DEADMAN_SEC:-900} seconds.
+              Restart worker after clearing stale locks.
+    - name: odds.pipeline
+      rules:
+        - alert: OddsPipelineStalled
+          expr: |
+            rate(sm_requests_total{component="odds"}[5m]) == 0
+            and on() (sm_matches_open_total > 0)
+          for: 5m
+          labels:
+            severity: warning
+            service: telegram-bot
+          annotations:
+            summary: "Odds pipeline stalled"
+            description: |
+              Odds provider requests halted for at least 5 minutes while matches are scheduled.
+              Check provider availability and adjust ODDS_TIMEOUT_SEC or retry settings.
+    - name: api.readiness
+      rules:
+        - alert: ApiReadinessCritical
+          expr: app_ready{status="fail"} == 1
+          for: 0m
+          labels:
+            severity: critical
+            service: telegram-bot
+          annotations:
+            summary: "API readiness probe failed"
+            description: |
+              /readyz returned HTTP 503 or reported degraded dependencies.
+              Inspect PRESTART_PREFLIGHT status and verify Postgres/Redis connectivity.

--- a/requirements.lock
+++ b/requirements.lock
@@ -16,6 +16,7 @@ scipy==1.16.2
 pyarrow==15.0.2
 loguru==0.7.3
 python-dotenv==1.1.1
+PyYAML==6.0.2
 sqlalchemy==2.0.43
 alembic==1.16.5
 pydantic-settings==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ scipy>=1.10.0,<2.0.0
 pyarrow>=15.0.0,<16.0.0
 loguru>=0.7.0,<1.0.0
 python-dotenv>=1.0.0,<2.0.0
+PyYAML>=6.0,<7.0
 sqlalchemy>=2.0.0,<3.0.0
 alembic>=1.10.0,<2.0.0
 pydantic-settings>=2.0.0,<3.0.0

--- a/tools/alerts_validate.py
+++ b/tools/alerts_validate.py
@@ -1,0 +1,62 @@
+"""
+@file: tools/alerts_validate.py
+@description: Validate Prometheus alert YAML syntax with optional PyYAML fallback.
+@created: 2025-10-30
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _basic_yaml_checks(text: str) -> None:
+    indent_stack = [0]
+    block_indent: int | None = None
+    for idx, raw in enumerate(text.splitlines(), 1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#") or stripped == "---":
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        if block_indent is not None and indent > block_indent:
+            continue
+        if block_indent is not None and indent <= block_indent:
+            block_indent = None
+        if indent % 2 != 0:
+            raise SystemExit(f"Invalid indentation on line {idx}: expected multiples of two spaces")
+        while indent_stack and indent < indent_stack[-1]:
+            indent_stack.pop()
+        current = indent_stack[-1] if indent_stack else 0
+        if indent > current and indent - current != 2:
+            raise SystemExit(f"Unexpected indentation step on line {idx}: got {indent}, expected {current + 2}")
+        if indent > current:
+            indent_stack.append(indent)
+        if stripped.startswith("-"):
+            if ":" in stripped.split("-", 1)[-1]:
+                if stripped.endswith("|") or stripped.endswith(">"):
+                    block_indent = indent
+                continue
+            if stripped == "-":
+                continue
+            continue
+        if ":" not in stripped:
+            raise SystemExit(f"Missing ':' separator on line {idx}")
+        if stripped.endswith("|") or stripped.endswith(">"):
+            block_indent = indent
+
+
+def main() -> None:
+    path = Path("monitoring/alerts.yaml")
+    if not path.exists():
+        raise SystemExit("monitoring/alerts.yaml not found")
+    text = path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+    except ModuleNotFoundError:
+        _basic_yaml_checks(text)
+        print(f"{path} basic structure OK (PyYAML not installed)")
+        return
+    yaml.safe_load(text)
+    print(f"{path} OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add PrometheusRule definitions for freshness, ETL, worker heartbeat, odds pipeline, and API readiness alerts
- provide alert threshold environment example and operational runbook documentation
- wire alerts validation into Makefile/CI and document monitoring setup in README

## Testing
- make alerts-validate
- make check

------
https://chatgpt.com/codex/tasks/task_e_68d6d1474674832eb11733d95105e988