### PR TITLE
Add QA-min offline dependency profile and self-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ PRECOMMIT ?= pre-commit
 PRE_COMMIT_HOME ?= .cache/pre-commit
 
 .PHONY: setup deps-fix lint lint-soft lint-strict lint-app lint-changed fmt test test-fast test-smoke test-all coverage-html \
-reports-gaps pre-commit-smart smoke pre-commit-offline check deps-lock deps-sync docker-build docker-run alerts-validate warmup
+reports-gaps pre-commit-smart smoke pre-commit-offline check deps-lock deps-sync qa-deps api-selftest docker-build docker-run \
+alerts-validate warmup
 
 IMAGE_NAME ?= telegram-bot
 APP_VERSION ?= 0.0.0
@@ -125,6 +126,12 @@ deps-lock:
 
 deps-sync:
 	$(PIP) install --no-index --find-links wheels/ -r requirements.lock
+
+qa-deps:
+	$(PY) -m tools.qa_deps_sync
+
+api-selftest:
+	$(PY) -m tools.api_selftest
 
 docker-build:
 	docker build --build-arg APP_VERSION=$(APP_VERSION) --build-arg GIT_SHA=$(GIT_SHA) \

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Sentry can be toggled via the `SENTRY_ENABLED` environment variable. Prometheus 
 - Для принудительного использования стабов выставьте `USE_OFFLINE_STUBS=1` (например, в CI или локально); чтобы использовать реальные зависимости, установите соответствующие пакеты и оставьте переменную пустой.
 - Тесты, помеченные `@pytest.mark.needs_np`, автоматически пропускаются, если стек `numpy/pandas` недоступен.
 
+## QA-min offline
+
+- Сложите необходимые колёса FastAPI-стека в каталог `wheels/` (например, `wheels/fastapi-*.whl`, `wheels/pydantic-*.whl`). Внутренние репозитории артефактов или архивы CI можно использовать как источник готовых wheels.
+- Лёгкий профиль зависимостей хранится в `requirements-qa-min.txt`; он не содержит жёстких пинов и подходит для офлайн-установки.
+- Запуск проверки: `make qa-deps && make line-health` для синхронизации зависимостей и привычного smoke-скрипта линий либо `make api-selftest` для локального запроса `/healthz` и `/readyz` через FastAPI `TestClient`.
+
 ## Reliability snapshot
 
 - **Single instance** — `app/runtime_lock.py` предотвращает параллельные запуски (lock в `/data/runtime.lock`).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,15 @@
+## [2024-05-09] - QA-min offline profile
+### Добавлено
+- Файл `requirements-qa-min.txt` с минимальным набором FastAPI-зависимостей для офлайн-аудита.
+- Скрипты `tools/qa_deps_sync.py` и `tools/api_selftest.py` для установки зависимостей из локальных wheels и проверки `/healthz`/`/readyz` через `TestClient`.
+- Makefile-цели `qa-deps` и `api-selftest`, упрощающие синхронизацию профиля и локальный self-test.
+
+### Изменено
+- README дополнен разделом «QA-min offline» с инструкциями по офлайн-установке и проверкам.
+
+### Исправлено
+- —
+
 ## [2025-11-26] - Migration comment syntax cleanup
 ### Добавлено
 - —

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: QA-min офлайн профиль
+- **Статус**: Завершена
+- **Описание**: Подготовить минимальный офлайн-профиль зависимостей для FastAPI и автоматизировать установку/self-test без изменения бизнес-кода.
+- **Шаги выполнения**:
+  - [x] Создан файл `requirements-qa-min.txt` с лёгким стеком FastAPI.
+  - [x] Добавлены скрипты `tools/qa_deps_sync.py` и `tools/api_selftest.py` с офлайн-логикой установки и self-test.
+  - [x] Обновлён `Makefile` (цели `qa-deps`, `api-selftest`) и README с разделом «QA-min offline».
+- **Зависимости**: requirements-qa-min.txt, tools/qa_deps_sync.py, tools/api_selftest.py, Makefile, README.md, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: Нормализация комментариев миграции 20241005_004
 - **Статус**: Завершена
 - **Описание**: Привести заголовок миграции `20241005_004_value_v1_4` к валидному Python-комментарию и подтвердить отсутствие синтаксических ошибок.

--- a/requirements-qa-min.txt
+++ b/requirements-qa-min.txt
@@ -1,0 +1,7 @@
+fastapi
+starlette
+anyio
+typing-extensions
+h11
+pydantic
+pydantic-settings

--- a/tools/api_selftest.py
+++ b/tools/api_selftest.py
@@ -1,0 +1,78 @@
+"""
+@file: tools/api_selftest.py
+@description: Offline FastAPI self-test runner for QA-min profile
+@dependencies: app.api:app, fastapi, starlette
+@created: 2024-05-09
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Dict
+
+
+def _collect_env_flags() -> Dict[str, str]:
+    relevant_prefixes = ("USE_", "OFFLINE", "NO_PROXY", "PIP_")
+    env_snapshot: Dict[str, str] = {}
+    for key, value in os.environ.items():
+        if key.startswith(relevant_prefixes):
+            env_snapshot[key] = value
+    return dict(sorted(env_snapshot.items()))
+
+
+def main() -> int:
+    env_snapshot = _collect_env_flags()
+    print("Environment snapshot for API self-test:")
+    if env_snapshot:
+        for key, value in env_snapshot.items():
+            print(f"- {key}={value}")
+    else:
+        print("- (no offline-related environment variables detected)")
+
+    try:
+        import fastapi  # noqa: F401  # pylint: disable=unused-import
+    except Exception:
+        print("fastapi missing, skipping API self-test")
+        return 0
+
+    try:
+        from starlette.testclient import TestClient
+    except Exception as exc:  # pragma: no cover - dependency missing scenario
+        print(f"Failed to import TestClient: {exc}")
+        return 1
+
+    try:
+        from app.api import app  # type: ignore[import]
+    except Exception as exc:
+        print(f"Failed to import app.api:app -> {exc}")
+        return 1
+
+    results: dict[str, dict[str, Any]] = {}
+    with TestClient(app) as client:  # type: ignore[arg-type]
+        for endpoint in ("/healthz", "/readyz"):
+            try:
+                response = client.get(endpoint)
+            except Exception as exc:  # pragma: no cover - runtime failure
+                results[endpoint] = {"error": str(exc)}
+                continue
+
+            payload: dict[str, Any]
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = {"raw": response.text}
+
+            results[endpoint] = {
+                "status_code": response.status_code,
+                "payload": payload,
+            }
+
+    print("API self-test results:")
+    print(json.dumps(results, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/qa_deps_sync.py
+++ b/tools/qa_deps_sync.py
@@ -1,0 +1,76 @@
+"""
+@file: tools/qa_deps_sync.py
+@description: Offline installer for QA-min dependency profile
+@dependencies: requirements-qa-min.txt, wheels/
+@created: 2024-05-09
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib import metadata
+from pathlib import Path
+from typing import Iterable
+
+
+def _read_packages(requirements_path: Path) -> list[str]:
+    packages: list[str] = []
+    for line in requirements_path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        packages.append(stripped.split()[0])
+    return packages
+
+
+def _print_report(packages: Iterable[str]) -> None:
+    print("QA-min dependency report:")
+    for name in packages:
+        try:
+            version = metadata.version(name)
+        except metadata.PackageNotFoundError:
+            print(f"- {name} (not installed)")
+        else:
+            print(f"- {name}=={version}")
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    requirements_path = repo_root / "requirements-qa-min.txt"
+    if not requirements_path.exists():
+        print("requirements-qa-min.txt missing, nothing to install")
+        return 0
+
+    wheels_dir = repo_root / "wheels"
+    wheel_files = sorted(wheels_dir.glob("*.whl")) if wheels_dir.exists() else []
+
+    packages = _read_packages(requirements_path)
+
+    if not wheel_files:
+        print("no wheels found, skipping install")
+        _print_report(packages)
+        return 0
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--no-index",
+        "--find-links",
+        str(wheels_dir),
+        "-r",
+        str(requirements_path),
+    ]
+    print("Installing QA-min dependencies from local wheels...")
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0:
+        return result.returncode
+
+    _print_report(packages)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a minimal FastAPI dependency profile for QA-min and offline installer helper
- provide an offline API self-test utility and hook both scripts into the Makefile
- document the QA-min workflow in the README, changelog, and task tracker

## Testing
- make qa-deps
- make api-selftest

------
https://chatgpt.com/codex/tasks/task_e_68d7f5b72cc0832e8c3ea2493f979ab8