### PR TITLE
fix: silence pytest asyncio config warning

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,13 @@
+## [2025-10-07] - Pytest asyncio compatibility shim
+### Добавлено
+- Регистрация ini-опции `asyncio_mode` в `tests/conftest.py`, чтобы офлайн-профили без `pytest-asyncio` оставались бесшумными.
+
+### Изменено
+- —
+
+### Исправлено
+- Устранено предупреждение `PytestConfigWarning` об неизвестной опции `asyncio_mode` при запуске тестов.
+
 ## [2025-10-01] - Offline QA resilience polish
 ### Добавлено
 - Заглушки для SportMonks-репозитория в офлайн-режиме через `_resolve_router` и диагностические сообщения.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: Pytest asyncio compatibility shim (2025-10-07)
+- **Статус**: Завершена
+- **Описание**: Устранить предупреждение PytestConfigWarning об неизвестной опции `asyncio_mode` в офлайн-профилях без `pytest-asyncio`.
+- **Шаги выполнения**:
+  - [x] Добавлен `pytest_addoption` в `tests/conftest.py`, регистрирующий ini-опцию `asyncio_mode`.
+  - [x] Обновлён `docs/changelog.md` с записью о совместимости Pytest.
+  - [x] Подтверждён чистый запуск `pytest -q` без предупреждения.
+- **Зависимости**: tests/conftest.py, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: Offline QA resilience polish (2025-10-01)
 - **Статус**: Завершена
 - **Описание**: Устранить офлайн-ошибки импортов и readiness, выявленные аудитом, без изменения бизнес-логики.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,3 +88,16 @@ def pytest_pyfunc_call(pyfuncitem):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "asyncio: mark async test for the local loop runner")
+
+
+def pytest_addoption(parser):
+    """Register compatibility ini options expected by pytest-asyncio."""
+
+    parser.addini(
+        "asyncio_mode",
+        (
+            "Compatibility shim for environments without pytest-asyncio where the "
+            "ini option is still referenced."
+        ),
+        default="auto",
+    )


### PR DESCRIPTION
## Summary
- register the `asyncio_mode` ini option via a pytest hook so offline test runs stay warning-free without pytest-asyncio
- document the compatibility shim in the changelog and task tracker

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d939a7f2e0832e9bd59b271c277ccb