### PR TITLE
feat: add lazy Alembic migrations runner and CI autoformat pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,21 @@ jobs:
         run: scripts/run_start_check.sh
 
       - name: Ruff autofix
-        run: |
-          python -m ruff check . --fix
-          python -m ruff format
-          python -m ruff check .
+        run: python -m ruff check . --fix
 
-      - name: Black
+      - name: Black format
+        run: python -m black .
+
+      - name: isort format
+        run: python -m isort .
+
+      - name: Ruff check
+        run: python -m ruff check .
+
+      - name: Black check
         run: python -m black --check .
 
-      - name: isort
+      - name: isort check
         run: python -m isort --check-only .
 
       - name: Pytest

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,15 @@
+## [2025-11-05] - Optional Alembic migrations & CI autoformat
+### Добавлено
+- Скрипт `scripts/migrations.py` с ленивой загрузкой Alembic и строгим режимом для продакшена.
+- Экстра `migrations` в `pyproject.toml`, подключающая `alembic>=1.13`, и dev-набор инструментов форматирования.
+
+### Изменено
+- `scripts/role_dispatch.py` поддерживает роль `migrate` с возвратом целочисленных кодов завершения.
+- GitHub Actions workflow `CI` выстраивает автофикс Ruff → Black → isort перед проверочными шагами.
+
+### Исправлено
+- `tests/conftest.py` пропускает Alembic-тесты, если пакет не установлен, и регистрирует новый маркер.
+
 ## [2025-11-04] - CI lint/test stabilization
 ### Добавлено
 - Конфигурация pytest-маркеров в `pyproject.toml` для единого управления офлайн-прогонами.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,14 @@
+## Задача: Optional Alembic migrations & CI autoformat (2025-11-05)
+- **Статус**: Завершена
+- **Описание**: Стандартизировать автоформатирование CI и сделать миграции опциональными с ленивой загрузкой Alembic.
+- **Шаги выполнения**:
+  - [x] Обновлён workflow `CI` для последовательности Ruff fix → Black → isort и проверочных шагов.
+  - [x] Добавлен модуль `scripts/migrations.py` с строгим режимом для роли миграций.
+  - [x] Расширен `scripts/role_dispatch.py` новой ролью `migrate` и корректными кодами завершения.
+  - [x] Зарегистрирован маркер `requires_alembic` и пропуск тестов без Alembic.
+  - [x] В `pyproject.toml` добавлены extras `migrations` и `dev`, обновлена документация (changelog, tasktracker).
+- **Зависимости**: .github/workflows/ci.yml, scripts/migrations.py, scripts/role_dispatch.py, tests/conftest.py, pyproject.toml, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: CI lint/test stabilization (2025-11-04)
 - **Статус**: Завершена
 - **Описание**: Упростить GitHub Actions под временный lint/test профиль, настроить общий pyproject и пропуски FastAPI-тестов.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,15 @@ dependencies = [
     "pyarrow>=15.0",
 ]
 
+[project.optional-dependencies]
+migrations = ["alembic>=1.13"]
+dev = [
+    "ruff>=0.6.0",
+    "black>=24.4.0",
+    "isort>=5.13.0",
+    "pytest>=8.0.0",
+]
+
 [project.scripts]
 diag-drift = "diagtools.drift:main"
 diag-run = "diagtools.run_diagnostics:main"
@@ -56,5 +65,6 @@ markers = [
     "slow: long-running tests skipped in fast profiles",
     "e2e: end-to-end scenarios involving external integrations",
     "requires_fastapi: test depends on FastAPI stack",
+    "requires_alembic: test depends on Alembic stack",
 ]
 filterwarnings = ["ignore::DeprecationWarning"]

--- a/scripts/migrations.py
+++ b/scripts/migrations.py
@@ -1,0 +1,80 @@
+"""
+@file: scripts/migrations.py
+@description: Lazy Alembic runner with strict/lenient modes for deployment roles.
+@dependencies: alembic, config.get_settings, database.db_router.mask_dsn, logger
+@created: 2025-11-05
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Any
+
+from config import Settings, get_settings
+from database.db_router import mask_dsn
+from logger import logger
+
+
+class AlembicUnavailableError(RuntimeError):
+    """Raised when Alembic modules cannot be imported."""
+
+
+def _load_alembic() -> tuple[ModuleType, type[Any]]:
+    try:
+        command_module = importlib.import_module("alembic.command")
+        config_module = importlib.import_module("alembic.config")
+    except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+        raise AlembicUnavailableError("Alembic package is not installed") from exc
+
+    config_type = getattr(config_module, "Config", None)
+    if config_type is None:  # pragma: no cover - defensive
+        raise AlembicUnavailableError("alembic.config.Config is unavailable")
+
+    return command_module, config_type
+
+
+def _make_config(settings: Settings, config_type: type[Any]) -> Any:
+    config = config_type()
+    config.set_main_option("script_location", "database/migrations")
+    config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+    return config
+
+
+def run_migrations(*, strict: bool = False) -> int:
+    """Run Alembic upgrade to head with optional strict mode."""
+
+    settings = get_settings()
+    masked_dsn = mask_dsn(settings.DATABASE_URL)
+    bound_logger = logger.bind(event="scripts.migrations", strict=strict, dsn=masked_dsn)
+
+    try:
+        command_module, config_type = _load_alembic()
+    except AlembicUnavailableError as exc:
+        if strict:
+            bound_logger.bind(error=str(exc)).error(
+                "Alembic is required for strict migrations; aborting"
+            )
+            return 1
+        bound_logger.bind(error=str(exc)).warning("Alembic not available; skipping migrations")
+        return 0
+
+    config = _make_config(settings, config_type)
+    bound_logger.info("Running Alembic upgrade to head")
+
+    try:
+        command_module.upgrade(config, "head")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        bound_logger.bind(error=str(exc)).error("Alembic upgrade failed")
+        return 1
+
+    bound_logger.info("Alembic upgrade finished")
+    return 0
+
+
+def main() -> int:
+    return run_migrations(strict=False)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a dedicated `scripts.migrations.run_migrations` helper that lazily imports Alembic and enforces strict mode failures
- expose the new migrate role in `scripts.role_dispatch`, align exit codes, and wire optional extras for Alembic/dev tooling
- standardize the CI workflow to run Ruff/Black/isort formatters before checks and document the optional-migrations flow

## Testing
- python -m black scripts/migrations.py scripts/role_dispatch.py tests/conftest.py
- python -m isort scripts/migrations.py scripts/role_dispatch.py tests/conftest.py
- python -m ruff check scripts/migrations.py scripts/role_dispatch.py tests/conftest.py *(fails: legacy E402 imports in tests/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_68da1d71cce0832e900d2cab230a95f4