### PR TITLE
Fix GLM training pipeline artifact handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m pip install -U pip
           if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
-          python -m pip install ruff black isort pytest
+          python -m pip install -e .[dev,ml,migrations]
 
       - name: Smoke check role dispatch
         env:

--- a/diagtools/settlement_check.py
+++ b/diagtools/settlement_check.py
@@ -139,8 +139,12 @@ def main(argv: list[str] | None = None) -> None:
         print("settlement_check: no picks")
         raise SystemExit(1)
     print(
-        "settlement_check: total={total} settled={settled} coverage={coverage:.2f} avg_roi={avg_roi:.2f}% window_roi={window_roi:.2f}%".format(
-            **summary.__dict__,
+        "settlement_check: total={t} settled={s} coverage={c:.2f} avg_roi={a:.2f}% window_roi={w:.2f}%".format(
+            t=summary.total,
+            s=summary.settled,
+            c=summary.coverage,
+            a=summary.avg_roi,
+            w=summary.window_roi,
         )
     )
     if summary.coverage < float(args.min_coverage) or summary.window_roi < float(args.roi_threshold):

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,14 @@
+## [2025-11-06] - GLM training hardening and settlement reporting fix
+### Добавлено
+- Экстра `ml` в `pyproject.toml` с зависимостями `numpy`, `pandas`, `scipy`, `statsmodels`, `scikit-learn`, устанавливаемая в CI для ML-пайплайнов.
+
+### Изменено
+- GitHub Actions workflow `CI` устанавливает проект через `pip install -e .[dev,ml,migrations]`, гарантируя доступность инструментов и ML-стека.
+
+### Исправлено
+- `diagtools/settlement_check.py` выводит итоги с явным обращением к полям `SettlementSummary`, корректно работая с dataclass `slots`.
+- `scripts/train_glm.py` создаёт корневой каталог реестра моделей и печатает traceback при сбоях, завершаясь кодом 1.
+
 ## [2025-09-29] - Pytest stub import hygiene
 ### Добавлено
 - Пакет `tests/_stubs/alembic` с заглушками `command` и `Config` для офлайн-прогонов.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,13 @@
+## Задача: Harden GLM pipeline and settlement summary (2025-11-06)
+- **Статус**: Завершена
+- **Описание**: Обеспечить корректное форматирование отчёта по расчётам, стабилизировать обучение GLM и подключить ML-зависимости в CI.
+- **Шаги выполнения**:
+  - [x] Исправлен вывод `diagtools/settlement_check.py`, избегая обращения к `__dict__` у dataclass со `slots`.
+  - [x] Доработан `scripts/train_glm.py` с созданием корневого каталога реестра и печатью traceback при ошибках.
+  - [x] Добавлена экстра `ml` в `pyproject.toml` и установка `pip install -e .[dev,ml,migrations]` в CI.
+  - [x] Обновлены `docs/changelog.md` и `docs/tasktracker.md` для фиксации правок.
+- **Зависимости**: diagtools/settlement_check.py, scripts/train_glm.py, pyproject.toml, .github/workflows/ci.yml, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: Fix Ruff E402 in tests/conftest.py (2025-09-29)
 - **Статус**: Завершена
 - **Описание**: Перевести импорты `tests/conftest.py` в верх файла, сохранив офлайн-стабы и регистрацию маркеров, и стабилизировать Alembic-заглушки.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,20 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-migrations = ["alembic>=1.13"]
 dev = [
     "ruff>=0.6.0",
     "black>=24.4.0",
     "isort>=5.13.0",
     "pytest>=8.0.0",
 ]
+ml = [
+    "numpy",
+    "pandas",
+    "scipy",
+    "statsmodels",
+    "scikit-learn",
+]
+migrations = ["alembic>=1.13"]
 
 [project.scripts]
 diag-drift = "diagtools.drift:main"

--- a/scripts/train_glm.py
+++ b/scripts/train_glm.py
@@ -11,6 +11,11 @@ import json
 import os
 from pathlib import Path
 import sys
+import traceback
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from typing import TYPE_CHECKING
 
@@ -25,10 +30,6 @@ if TYPE_CHECKING:  # pragma: no cover - typing aid
     import joblib as _joblib
     import numpy as _np
     import pandas as _pd
-
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 
 from app.data_processor import build_features, to_model_matrix, validate_input
 
@@ -90,6 +91,7 @@ def main() -> None:
     model_home, model_away, info = train_models(raw_df, args.alpha, args.l2)
     data_root = Path(os.getenv("DATA_ROOT", "/data"))
     registry_root = Path(os.getenv("MODEL_REGISTRY_PATH", str(data_root / "artifacts")))
+    registry_root.mkdir(parents=True, exist_ok=True)
     out_dir = registry_root / str(args.season_id)
     out_dir.mkdir(parents=True, exist_ok=True)
     joblib.dump(model_home, out_dir / "glm_home.pkl")
@@ -99,4 +101,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- fix the settlement summary CLI to format output via explicit fields so slots-based summaries work
- harden `scripts/train_glm.py` by ensuring the registry root exists, adding traceback logging, and guaranteeing the package path is importable
- add an `ml` optional dependency group, install it during CI, and document the changes in the changelog and task tracker

## Testing
- ✅ `pytest -q tests/diag/test_settlement_check.py::test_settlement_check_fail`
- ✅ `pytest -q tests/ml/test_glm_training.py::test_train_glm_and_pipeline`
- ❌ `ruff check .` *(fails with numerous pre-existing lint violations outside this change)*
- ❌ `black --check .` *(fails due to existing repository formatting drift)*
- ❌ `isort --check-only .` *(fails from long-standing import ordering issues)*
- ✅ `ROLE="O'Reilly" scripts/run_start_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68da23e431e4832e8c1c0f6d62ba90c7