### PR TITLE
Fix ASGI app resolution in Amvera API server

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,13 @@
+## [2025-11-10] - ASGI resolution hardening for Amvera
+### Добавлено
+- —
+
+### Изменено
+- `scripts/api_server.py` добавляет корень проекта в `sys.path`, выбирает первый доступный ASGI-тартет из `app.api:app`, `app.main:app`, `api:app`, `main:app` и передаёт объект приложения в `uvicorn.run`.
+
+### Исправлено
+- Исключена ошибка `ModuleNotFoundError` при запуске через Amvera Configurator благодаря явной загрузке ASGI-приложения.
+
 ## [2025-11-09] - Amvera API logging and runtime alignment
 ### Добавлено
 - —

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: Resolve ASGI target for Amvera Configurator (2025-11-10)
+- **Статус**: Завершена
+- **Описание**: Обеспечить корректный запуск uvicorn в окружении Amvera, добавив корень проекта в `sys.path` и явное разрешение ASGI-приложения.
+- **Шаги выполнения**:
+  - [x] Добавлен корневой путь проекта в `sys.path` внутри `scripts/api_server.py` перед загрузкой модулей.
+  - [x] Реализован перебор целей `app.api:app`, `app.main:app`, `api:app`, `main:app` с возвратом найденного объекта приложения uvicorn.
+  - [x] Обновлены `docs/changelog.md` и `docs/tasktracker.md` для фиксации улучшений.
+- **Зависимости**: scripts/api_server.py, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: Align Amvera deployment runtime (2025-11-09)
 - **Статус**: Завершена
 - **Описание**: Синхронизировать сервер API Amvera с портом контейнера, ранними логами и настройками Python 3.11.


### PR DESCRIPTION
## Summary
- ensure the Amvera API bootstrap prepends the project root to sys.path
- resolve the ASGI application by importing common targets and pass the object into uvicorn.run
- record the operational update in the changelog and task tracker

## Testing
- python -m compileall scripts/api_server.py

------
https://chatgpt.com/codex/tasks/task_e_68dabe7708a4832ead766c1b339f424f