### PR TITLE
fix: harden Telegram bot logger resolution

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,14 @@
+## [2025-09-29] - Telegram bot logger resolution hardening
+### Добавлено
+- —
+
+### Изменено
+- `scripts/tg_bot.py` добавляет корень проекта в `sys.path` перед загрузкой зависимостей Telegram-бота.
+- Реализовано последовательное разрешение логгера из `logger`, `app.logger`, `common.logger`, `app.utils.logger` с сообщением об успешном импорте.
+
+### Исправлено
+- Исключён `ModuleNotFoundError` при запуске Amvera worker за счёт резервного `logging.basicConfig` и fallback-логгера.
+
 ## [2025-11-10] - ASGI resolution hardening for Amvera
 ### Добавлено
 - —

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: Harden Telegram bot logger resolution (2025-09-29)
+- **Статус**: Завершена
+- **Описание**: Обеспечить запуск воркера Amvera без ошибок импорта, расширив поиск логгера и добавив корень проекта в `sys.path`.
+- **Шаги выполнения**:
+  - [x] Добавлен корневой путь проекта в `sys.path` внутри `scripts/tg_bot.py` до загрузки зависимостей.
+  - [x] Реализован многоступенчатый резолвер логгера с перебором `logger`, `app.logger`, `common.logger`, `app.utils.logger` и fallback на `logging.basicConfig`.
+  - [x] Обновлены `docs/changelog.md` и `docs/tasktracker.md` для фиксации изменений.
+- **Зависимости**: scripts/tg_bot.py, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: Resolve ASGI target for Amvera Configurator (2025-11-10)
 - **Статус**: Завершена
 - **Описание**: Обеспечить корректный запуск uvicorn в окружении Amvera, добавив корень проекта в `sys.path` и явное разрешение ASGI-приложения.


### PR DESCRIPTION
## Summary
- ensure scripts/tg_bot.py prepends the project root to sys.path before imports
- add a resilient logger resolver that checks multiple modules and falls back to logging.basicConfig
- record the logger changes in the changelog and task tracker

## Testing
- python -m compileall scripts/tg_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68dad2190e68832eb47b7f7ffd3d399a