### PR TITLE
feat: add telegram bot startup diagnostics

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,14 @@
+## [2025-11-14] - Telegram bot startup diagnostics
+### Добавлено
+- Диагностический вывод `scripts/tg_bot.py` печатает `sys.path` и содержимое каталога `telegram` при запуске.
+- Встроенная заглушка `telegram.middlewares` регистрируется динамически при отсутствии файла `middlewares.py`.
+
+### Изменено
+- —
+
+### Исправлено
+- —
+
 ## [2025-11-13] - Telegram package relative imports
 ### Добавлено
 - —

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: Telegram bot diagnostics for Amvera (2025-11-14)
+- **Статус**: Завершена
+- **Описание**: Добавить диагностический вывод и заглушку middleware для запуска воркера Amvera без ошибок импорта.
+- **Шаги выполнения**:
+  - [x] Вывел список `sys.path` и содержимое каталога `telegram` в `scripts/tg_bot.py` перед импортами.
+  - [x] Добавил динамическую заглушку `telegram.middlewares` с `register_middlewares`, если отсутствует файл `middlewares.py`.
+  - [x] Обновил документацию (changelog, tasktracker) согласно правилам проекта.
+- **Зависимости**: scripts/tg_bot.py, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: Resolve Telegram worker imports (2025-11-13)
 - **Статус**: Завершена
 - **Описание**: Сделать локальный пакет `telegram` корректно резолвимым в воркере Amvera через относительные импорты.

--- a/scripts/tg_bot.py
+++ b/scripts/tg_bot.py
@@ -12,12 +12,40 @@ import importlib
 import logging
 import signal
 import sys
+import types
 from contextlib import suppress
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+TELEGRAM_DIR = PROJECT_ROOT / "telegram"
+
+print("[tg_bot] sys.path entries:")
+for index, entry in enumerate(sys.path):
+    print(f"  [{index}] {entry}")
+
+if TELEGRAM_DIR.exists():
+    telegram_contents = sorted(item.name for item in TELEGRAM_DIR.iterdir())
+    print("[tg_bot] telegram package contents:")
+    for name in telegram_contents:
+        print(f"  - {name}")
+else:
+    print(f"[tg_bot] telegram directory missing at {TELEGRAM_DIR}")
+
+middlewares_module_path = TELEGRAM_DIR / "middlewares.py"
+if not middlewares_module_path.exists():
+    print("[tg_bot] middlewares.py not found, installing stub telegram.middlewares")
+
+    stub_module = types.ModuleType("telegram.middlewares")
+
+    def register_middlewares(dispatcher):  # type: ignore[unused-arg]
+        print("[tg_bot] register_middlewares stub invoked")
+        return dispatcher
+
+    stub_module.register_middlewares = register_middlewares  # type: ignore[attr-defined]
+    sys.modules["telegram.middlewares"] = stub_module
 
 
 def _resolve_logger() -> logging.Logger:


### PR DESCRIPTION
## Summary
- print the resolved `sys.path` entries and `telegram` directory contents when launching the bot script
- provide a temporary `telegram.middlewares` stub that exposes `register_middlewares` if the module file is absent
- record the diagnostics update in the changelog and task tracker

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db945979d0832e8a9db1fe16f6fa5e