### PR TITLE
Harden Telegram worker bootstrap and add preflight check

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ git push amvera main
 Для оффлайн-прогона value-фич установите `ENABLE_VALUE_FEATURES=1`, `ODDS_PROVIDER=csv` и
 `ODDS_FIXTURES_PATH=tests/fixtures/odds`. Так `diagtools.value_check` и тесты будут работать без внешнего API.
 
+## Amvera worker
+
+- **Script:** `scripts/tg_bot.py`
+- **Runtime:** Python 3.11 (pip toolchain)
+- **Required env:** `ROLE=bot`, `TELEGRAM_BOT_TOKEN`, `PYTHONUNBUFFERED=1`, `LOG_LEVEL=INFO`, `PYTHONPATH=.`
+- **Optional preflight:** `python scripts/preflight_worker.py`
+
 ### Хранилище
 
 Amvera монтирует постоянный том в `/data`. Все изменяемые файлы (SQLite, отчёты, артефакты моделей, логи) сохраняются в этом каталоге, код и артефакты сборки остаются неизменными.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,15 @@
+## [2025-09-30] - Telegram worker bootstrap hardening
+### Добавлено
+- `scripts/preflight_worker.py` выполняет проверку импортов `telegram.bot` и `telegram.middlewares` перед запуском воркера.
+
+### Изменено
+- `scripts/tg_bot.py` добавляет корень проекта в `sys.path`, включает fallback-логгер и выводит диагностику наличия `telegram.middlewares`.
+- `telegram/bot.py` переключён на относительные импорты, исключая конфликты с PyPI-пакетом `telegram`.
+- `README.md` документирует профиль воркера Amvera и preflight-скрипт.
+
+### Исправлено
+- Исключено переопределение `telegram.middlewares` в рантайме и падения воркера из-за неправильных путей импорта.
+
 ## [2025-11-10] - ASGI resolution hardening for Amvera
 ### Добавлено
 - —

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,13 @@
+## Задача: Harden Telegram worker imports (2025-09-30)
+- **Статус**: Завершена
+- **Описание**: Удалить стабы `telegram.middlewares`, выровнять импорты и добавить префлайт Amvera-воркера.
+- **Шаги выполнения**:
+  - [x] Доработан `scripts/tg_bot.py` с вставкой корня проекта в `sys.path`, fallback-логгером и диагностикой наличия `telegram.middlewares`.
+  - [x] Переключён `telegram/bot.py` на относительные импорты middlewares и роутеров.
+  - [x] Добавлен `scripts/preflight_worker.py` для проверки импортов перед запуском воркера.
+  - [x] Обновлены `README.md`, `docs/changelog.md` и `docs/tasktracker.md`.
+- **Зависимости**: scripts/tg_bot.py, telegram/bot.py, scripts/preflight_worker.py, README.md, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: Resolve ASGI target for Amvera Configurator (2025-11-10)
 - **Статус**: Завершена
 - **Описание**: Обеспечить корректный запуск uvicorn в окружении Amvera, добавив корень проекта в `sys.path` и явное разрешение ASGI-приложения.

--- a/scripts/preflight_worker.py
+++ b/scripts/preflight_worker.py
@@ -1,0 +1,31 @@
+"""
+@file: scripts/preflight_worker.py
+@description: Preflight check ensuring worker dependencies are importable.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import importlib
+
+
+def _check(module_name: str) -> None:
+    importlib.import_module(module_name)
+    print(f"preflight: import {module_name}: OK", flush=True)
+
+
+def main() -> None:
+    print("preflight: starting", flush=True)
+    _check("telegram.bot")
+    _check("telegram.middlewares")
+    print("preflight: OK", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -14,7 +14,7 @@ from app.utils import retry_async
 from config import settings
 from database.cache_postgres import init_cache
 from logger import logger
-from telegram.middlewares import (
+from .middlewares import (
     IdempotencyMiddleware,
     ProcessingTimeMiddleware,
     RateLimitMiddleware,
@@ -81,7 +81,7 @@ class TelegramBot:
         if not self.dp:
             raise RuntimeError("Диспетчер не инициализирован")
         try:
-            from telegram.handlers import register_handlers
+            from .handlers import register_handlers
 
             register_handlers(self.dp)
             logger.info("✅ Роутеры зарегистрированы")


### PR DESCRIPTION
## Summary
- add sys.path bootstrap, fallback logging, and build metadata logging to the Telegram worker entrypoint
- switch Telegram bot middlewares to relative imports and document the Amvera worker profile
- introduce a reusable preflight script and update changelog/task tracker entries

## Testing
- python -m compileall scripts/tg_bot.py telegram/bot.py telegram/middlewares.py scripts/preflight_worker.py
- python scripts/preflight_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68dbb79bcab8832eac55270dfcd73767