### PR TITLE
Add async rate limiter for Telegram bot messaging

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,17 @@
+## [2025-10-02] - Telegram bot local rate limiter
+### Добавлено
+- Асинхронный скользящий rate-limiter `tgbotapp/ratelimiter.py` и обёртка `tgbotapp/sender.py`
+  с безопасной отправкой сообщений.
+- Юнит-тесты `tests/telegram/test_rate_limiter.py`, подтверждающие глобальные, чатовые и
+  групповые ограничения, а также обёртку `safe_send_text`.
+
+### Изменено
+- Хендлеры `tgbotapp/handlers/*` переключены на `safe_send_text`, чтобы учитывать новые лимиты
+  перед отправкой сообщений, и пакет `tgbotapp` экспортирует `ratelimiter`/`sender`.
+
+### Исправлено
+- —
+
 ## [2025-10-05] - SportMonks pagination & rate-limit handling
 ### Добавлено
 - Интеграционные тесты `tests/integrations/test_sportmonks_date_timezone_and_pagination.py`,

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,15 @@
+## Задача: Telegram bot local rate limiter (2025-10-02)
+- **Статус**: Завершена
+- **Описание**: Ввести локальный rate-limiter для Telegram-бота с глобальными, чатовым и групповым
+  окнами и заменить отправку сообщений на безопасную обёртку.
+- **Шаги выполнения**:
+  - [x] Реализован `tgbotapp/ratelimiter.py` со скользящими окнами и общим состоянием.
+  - [x] Добавлена обёртка `tgbotapp/sender.py` и обновлены хендлеры `tgbotapp/handlers/*`.
+  - [x] Дополнены тесты `tests/telegram/test_rate_limiter.py` проверками ограничений и safe sender.
+  - [x] Обновлены `tgbotapp/__init__.py`, `docs/changelog.md`, `docs/tasktracker.md`.
+- **Зависимости**: tgbotapp/ratelimiter.py, tgbotapp/sender.py, tgbotapp/handlers/*, tests/telegram/test_rate_limiter.py,
+  tgbotapp/__init__.py, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: SportMonks pagination & retry hardening (2025-10-05)
 - **Статус**: Завершена
 - **Описание**: Добавить пагинацию, режимы авторизации, валидацию диапазонов и обработку 429

--- a/tests/telegram/test_rate_limiter.py
+++ b/tests/telegram/test_rate_limiter.py
@@ -1,0 +1,109 @@
+"""
+/**
+ * @file: tests/telegram/test_rate_limiter.py
+ * @description: Tests for AsyncRateLimiter behaviour and safe message sending wrapper.
+ * @dependencies: asyncio, pytest, tgbotapp.sender
+ * @created: 2025-10-02
+ */
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from tgbotapp.ratelimiter import AsyncRateLimiter
+from tgbotapp.sender import get_rate_limiter, safe_send_text, set_rate_limiter
+
+
+class _StubLimiter:
+    def __init__(self) -> None:
+        self.calls: list[int | str] = []
+
+    async def acquire(self, chat_id: int | str) -> None:
+        self.calls.append(chat_id)
+
+
+class _StubBot:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int | str, str, dict[str, Any]]] = []
+
+    async def send_message(
+        self, *, chat_id: int | str, text: str, **kwargs: Any
+    ) -> dict[str, Any]:
+        payload = {"chat_id": chat_id, "text": text, **kwargs}
+        self.calls.append((chat_id, text, kwargs))
+        return payload
+
+
+@pytest.mark.asyncio
+async def test_safe_send_text_invokes_limiter_and_bot_call() -> None:
+    bot = _StubBot()
+    limiter = _StubLimiter()
+    original = get_rate_limiter()
+    set_rate_limiter(limiter)
+    try:
+        result = await safe_send_text(bot, 123, "hello", parse_mode="HTML")
+    finally:
+        set_rate_limiter(original)
+    assert limiter.calls == [123]
+    assert bot.calls == [(123, "hello", {"parse_mode": "HTML"})]
+    assert result["text"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_per_chat_limit_spacing() -> None:
+    limiter = AsyncRateLimiter(
+        global_limit=10,
+        global_window=0.01,
+        per_chat_limit=1,
+        per_chat_window=0.05,
+        group_limit=10,
+        group_window=0.05,
+    )
+    loop = asyncio.get_running_loop()
+    await limiter.acquire(42)
+    before = loop.time()
+    await limiter.acquire(42)
+    after = loop.time()
+    assert after - before >= 0.045
+
+
+@pytest.mark.asyncio
+async def test_global_limit_across_chats() -> None:
+    limiter = AsyncRateLimiter(
+        global_limit=2,
+        global_window=0.05,
+        per_chat_limit=5,
+        per_chat_window=0.01,
+        group_limit=10,
+        group_window=0.05,
+    )
+    loop = asyncio.get_running_loop()
+    await limiter.acquire(1)
+    await limiter.acquire(2)
+    before = loop.time()
+    await limiter.acquire(3)
+    after = loop.time()
+    assert after - before >= 0.045
+
+
+@pytest.mark.asyncio
+async def test_group_limit_stricter_than_per_chat() -> None:
+    limiter = AsyncRateLimiter(
+        global_limit=10,
+        global_window=0.01,
+        per_chat_limit=5,
+        per_chat_window=0.01,
+        group_limit=2,
+        group_window=0.05,
+    )
+    loop = asyncio.get_running_loop()
+    chat_id = -100123
+    await limiter.acquire(chat_id)
+    await limiter.acquire(chat_id)
+    before = loop.time()
+    await limiter.acquire(chat_id)
+    after = loop.time()
+    assert after - before >= 0.045

--- a/tgbotapp/__init__.py
+++ b/tgbotapp/__init__.py
@@ -9,6 +9,8 @@ __all__ = [
     "handlers",
     "middlewares",
     "models",
+    "ratelimiter",
+    "sender",
     "services",
     "utils",
     "widgets",

--- a/tgbotapp/handlers/help.py
+++ b/tgbotapp/handlers/help.py
@@ -11,6 +11,7 @@ from aiogram.filters import Command
 from aiogram.types import Message
 
 from tgbotapp.dependencies import BotDependencies, CommandInfo
+from tgbotapp.sender import safe_send_text
 
 
 def build_help_text(commands: tuple[CommandInfo, ...] | list[CommandInfo]) -> str:
@@ -27,6 +28,6 @@ def create_router(deps: BotDependencies) -> Router:
 
     @router.message(Command("help"))
     async def handle_help(message: Message) -> None:  # pragma: no cover - executed in runtime
-        await message.answer(help_text, parse_mode="HTML")
+        await safe_send_text(message.bot, message.chat.id, help_text, parse_mode="HTML")
 
     return router

--- a/tgbotapp/handlers/model.py
+++ b/tgbotapp/handlers/model.py
@@ -11,6 +11,7 @@ from aiogram.filters import Command
 from aiogram.types import Message
 
 from tgbotapp.dependencies import BotDependencies, ModelMetadata
+from tgbotapp.sender import safe_send_text
 
 
 def render_model_info(meta: ModelMetadata) -> str:
@@ -34,6 +35,6 @@ def create_router(deps: BotDependencies) -> Router:
 
     @router.message(Command("model"))
     async def handle_model(message: Message) -> None:  # pragma: no cover - executed in runtime
-        await message.answer(model_text, parse_mode="HTML")
+        await safe_send_text(message.bot, message.chat.id, model_text, parse_mode="HTML")
 
     return router

--- a/tgbotapp/handlers/predict.py
+++ b/tgbotapp/handlers/predict.py
@@ -17,6 +17,7 @@ from aiogram.types import Message
 
 from logger import logger
 from tgbotapp.dependencies import BotDependencies
+from tgbotapp.sender import safe_send_text
 
 _USAGE_MESSAGE = "Укажите команды в формате «Команда 1 — Команда 2»."
 _MISSING_TEAMS_MESSAGE = "Нужно указать обе команды."
@@ -66,7 +67,7 @@ def create_router(deps: BotDependencies) -> Router:
         args = message.text.split(maxsplit=1)
         query = args[1] if len(args) > 1 else ""
         response = await build_predict_response(deps, message.chat.id, query)
-        await message.answer(response, parse_mode="HTML")
+        await safe_send_text(message.bot, message.chat.id, response, parse_mode="HTML")
         logger.debug("Predict command processed for chat %s", message.chat.id)
 
     return router

--- a/tgbotapp/handlers/start.py
+++ b/tgbotapp/handlers/start.py
@@ -22,6 +22,7 @@ from config import settings
 from logger import logger
 from tgbotapp.handlers.terms import DISCLAIMER_TEXT
 from tgbotapp.models import CommandWithoutArgs
+from tgbotapp.sender import safe_send_text
 
 
 @dataclass(slots=True)
@@ -141,7 +142,9 @@ def _main_menu_builder() -> InlineKeyboardBuilder:
 async def _send_main_menu(message: Message) -> None:
     try:
         builder = _main_menu_builder()
-        await message.answer(
+        await safe_send_text(
+            message.bot,
+            message.chat.id,
             "🏆 <b>Главное меню Football Predictor Bot</b>\nВыберите действие из меню ниже:",
             reply_markup=builder.as_markup(),
             parse_mode="HTML",
@@ -153,7 +156,12 @@ async def _send_main_menu(message: Message) -> None:
             message.from_user.id,
             exc,
         )
-        await message.answer("❌ Ошибка при отправке меню. Попробуйте позже.", parse_mode="HTML")
+        await safe_send_text(
+            message.bot,
+            message.chat.id,
+            "❌ Ошибка при отправке меню. Попробуйте позже.",
+            parse_mode="HTML",
+        )
 
 
 async def _edit_or_send_main_menu(callback: CallbackQuery) -> None:
@@ -169,9 +177,14 @@ async def _edit_or_send_main_menu(callback: CallbackQuery) -> None:
             callback.from_user.id,
             exc,
         )
-        await callback.message.answer(
-            menu_text, reply_markup=builder.as_markup(), parse_mode="HTML"
-        )
+        if callback.message:
+            await safe_send_text(
+                callback.bot,
+                callback.message.chat.id,
+                menu_text,
+                reply_markup=builder.as_markup(),
+                parse_mode="HTML",
+            )
     await callback.answer()
 
 
@@ -207,7 +220,9 @@ async def cmd_start(message: Message) -> None:
             message.from_user.id,
             message.from_user.username or "N/A",
         )
-        await message.answer(
+        await safe_send_text(
+            message.bot,
+            message.chat.id,
             "👋 <b>Добро пожаловать в Football Predictor Bot!</b>\n\n"
             "🤖 Я использую продвинутые алгоритмы ИИ и статистические модели для "
             "прогнозирования исходов футбольных матчей.\n"
@@ -218,15 +233,18 @@ async def cmd_start(message: Message) -> None:
         )
         await _send_main_menu(message)
     except ValueError as exc:
-        await message.answer(f"❌ {exc}", parse_mode="HTML")
+        await safe_send_text(message.bot, message.chat.id, f"❌ {exc}", parse_mode="HTML")
     except Exception as exc:  # pragma: no cover - defensive fallback
         logger.error(
             "Ошибка в обработчике /start для пользователя %s: %s",
             message.from_user.id,
             exc,
         )
-        await message.answer(
-            "❌ Произошла ошибка при запуске бота. Попробуйте позже.", parse_mode="HTML"
+        await safe_send_text(
+            message.bot,
+            message.chat.id,
+            "❌ Произошла ошибка при запуске бота. Попробуйте позже.",
+            parse_mode="HTML",
         )
 
 
@@ -273,9 +291,14 @@ async def show_help(callback: CallbackQuery) -> None:
                 callback.from_user.id,
                 exc,
             )
-            await callback.message.answer(
-                help_text, reply_markup=builder.as_markup(), parse_mode="HTML"
-            )
+            if callback.message:
+                await safe_send_text(
+                    callback.bot,
+                    callback.message.chat.id,
+                    help_text,
+                    reply_markup=builder.as_markup(),
+                    parse_mode="HTML",
+                )
         await callback.answer()
     except Exception as exc:  # pragma: no cover - defensive fallback
         logger.error("Ошибка в обработчике справки: %s", exc)
@@ -309,9 +332,14 @@ async def show_examples(callback: CallbackQuery) -> None:
                 callback.from_user.id,
                 exc,
             )
-            await callback.message.answer(
-                examples_text, reply_markup=builder.as_markup(), parse_mode="HTML"
-            )
+            if callback.message:
+                await safe_send_text(
+                    callback.bot,
+                    callback.message.chat.id,
+                    examples_text,
+                    reply_markup=builder.as_markup(),
+                    parse_mode="HTML",
+                )
         await callback.answer()
     except Exception as exc:  # pragma: no cover - defensive fallback
         logger.error("Ошибка в обработчике примеров: %s", exc)
@@ -336,9 +364,14 @@ async def show_stats(callback: CallbackQuery) -> None:
                 callback.from_user.id,
                 exc,
             )
-            await callback.message.answer(
-                stats_text, reply_markup=builder.as_markup(), parse_mode="HTML"
-            )
+            if callback.message:
+                await safe_send_text(
+                    callback.bot,
+                    callback.message.chat.id,
+                    stats_text,
+                    reply_markup=builder.as_markup(),
+                    parse_mode="HTML",
+                )
         await callback.answer()
     except Exception as exc:  # pragma: no cover - defensive fallback
         logger.error("Ошибка в обработчике статистики: %s", exc)
@@ -374,12 +407,15 @@ async def show_terms(callback: CallbackQuery) -> None:
                 callback.from_user.id,
                 exc,
             )
-            await callback.message.answer(
-                terms_text,
-                reply_markup=builder.as_markup(),
-                parse_mode="HTML",
-                disable_web_page_preview=True,
-            )
+            if callback.message:
+                await safe_send_text(
+                    callback.bot,
+                    callback.message.chat.id,
+                    terms_text,
+                    reply_markup=builder.as_markup(),
+                    parse_mode="HTML",
+                    disable_web_page_preview=True,
+                )
         await callback.answer()
     except Exception as exc:  # pragma: no cover - defensive fallback
         logger.error("Ошибка в обработчике условий: %s", exc)
@@ -405,9 +441,14 @@ async def show_disclaimer(callback: CallbackQuery) -> None:
                 callback.from_user.id,
                 exc,
             )
-            await callback.message.answer(
-                disclaimer_text, reply_markup=builder.as_markup(), parse_mode="HTML"
-            )
+            if callback.message:
+                await safe_send_text(
+                    callback.bot,
+                    callback.message.chat.id,
+                    disclaimer_text,
+                    reply_markup=builder.as_markup(),
+                    parse_mode="HTML",
+                )
         await callback.answer()
     except Exception as exc:  # pragma: no cover - defensive fallback
         logger.error("Ошибка в обработчике дисклеймера: %s", exc)

--- a/tgbotapp/handlers/today.py
+++ b/tgbotapp/handlers/today.py
@@ -14,6 +14,7 @@ from aiogram.types import Message
 
 from logger import logger
 from tgbotapp.dependencies import BotDependencies
+from tgbotapp.sender import safe_send_text
 from tgbotapp.widgets import format_fixture_list
 
 
@@ -37,6 +38,6 @@ def create_router(deps: BotDependencies) -> Router:
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("Не удалось получить список матчей: %s", exc)
             text = "❌ Не удалось получить список матчей."
-        await message.answer(text, parse_mode="HTML")
+        await safe_send_text(message.bot, message.chat.id, text, parse_mode="HTML")
 
     return router

--- a/tgbotapp/ratelimiter.py
+++ b/tgbotapp/ratelimiter.py
@@ -1,0 +1,146 @@
+"""
+/**
+ * @file: tgbotapp/ratelimiter.py
+ * @description: Sliding-window asynchronous rate limiter for Telegram bot messaging.
+ * @dependencies: asyncio, collections, typing
+ * @created: 2025-10-02
+ */
+"""
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from time import monotonic
+from typing import Deque, Iterable, MutableMapping
+
+ChatId = int | str
+
+
+class _SlidingWindow:
+    """Utility class encapsulating sliding window counters."""
+
+    __slots__ = ("limit", "window", "events")
+
+    def __init__(self, limit: int, window: float) -> None:
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        if window <= 0:
+            raise ValueError("window must be positive")
+        self.limit = limit
+        self.window = window
+        self.events: Deque[float] = deque()
+
+    def prune(self, now: float) -> None:
+        cutoff = now - self.window
+        events = self.events
+        while events and events[0] <= cutoff:
+            events.popleft()
+
+    def register(self, timestamp: float) -> None:
+        self.events.append(timestamp)
+
+    def compute_delay(self, now: float) -> float:
+        self.prune(now)
+        if len(self.events) < self.limit:
+            return 0.0
+        oldest = self.events[0]
+        return max(0.0, oldest + self.window - now)
+
+
+class AsyncRateLimiter:
+    """Asynchronous rate limiter with global, per-chat and group limits."""
+
+    def __init__(
+        self,
+        *,
+        global_limit: int = 30,
+        global_window: float = 1.0,
+        per_chat_limit: int = 1,
+        per_chat_window: float = 1.0,
+        group_limit: int = 20,
+        group_window: float = 60.0,
+    ) -> None:
+        if global_limit <= 0:
+            raise ValueError("global_limit must be positive")
+        if per_chat_limit <= 0:
+            raise ValueError("per_chat_limit must be positive")
+        if group_limit <= 0:
+            raise ValueError("group_limit must be positive")
+
+        self._global_window = _SlidingWindow(global_limit, global_window)
+        self._per_chat_limit = per_chat_limit
+        self._per_chat_window = per_chat_window
+        self._group_limit = group_limit
+        self._group_window = group_window
+        self._per_chat_windows: MutableMapping[ChatId, _SlidingWindow] = {}
+        self._group_windows: MutableMapping[ChatId, _SlidingWindow] = {}
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, chat_id: ChatId) -> None:
+        """Wait until sending a message to chat_id is allowed."""
+
+        while True:
+            async with self._lock:
+                now = monotonic()
+                wait_for = self._collect_wait_times(chat_id, now)
+                delay = max(wait_for, default=0.0)
+                if delay <= 0.0:
+                    self._register(now, chat_id)
+                    return
+            await asyncio.sleep(delay)
+
+    def _collect_wait_times(self, chat_id: ChatId, now: float) -> Iterable[float]:
+        waits = [self._global_window.compute_delay(now)]
+
+        per_chat_window = self._per_chat_windows.get(chat_id)
+        if per_chat_window is None:
+            per_chat_window = _SlidingWindow(self._per_chat_limit, self._per_chat_window)
+            self._per_chat_windows[chat_id] = per_chat_window
+        waits.append(per_chat_window.compute_delay(now))
+
+        if self._is_group(chat_id):
+            group_window = self._group_windows.get(chat_id)
+            if group_window is None:
+                group_window = _SlidingWindow(self._group_limit, self._group_window)
+                self._group_windows[chat_id] = group_window
+            waits.append(group_window.compute_delay(now))
+
+        self._cleanup_stale(now)
+        return waits
+
+    def _register(self, timestamp: float, chat_id: ChatId) -> None:
+        self._global_window.register(timestamp)
+
+        per_chat_window = self._per_chat_windows.setdefault(
+            chat_id,
+            _SlidingWindow(self._per_chat_limit, self._per_chat_window),
+        )
+        per_chat_window.register(timestamp)
+
+        if self._is_group(chat_id):
+            group_window = self._group_windows.setdefault(
+                chat_id,
+                _SlidingWindow(self._group_limit, self._group_window),
+            )
+            group_window.register(timestamp)
+
+    def _cleanup_stale(self, now: float) -> None:
+        for windows in (self._per_chat_windows, self._group_windows):
+            empty_keys: list[ChatId] = []
+            for chat_id, window in windows.items():
+                window.prune(now)
+                if not window.events:
+                    empty_keys.append(chat_id)
+            for chat_id in empty_keys:
+                del windows[chat_id]
+
+    @staticmethod
+    def _is_group(chat_id: ChatId) -> bool:
+        if isinstance(chat_id, int):
+            return chat_id < 0
+        if isinstance(chat_id, str):
+            return chat_id.startswith("-")
+        return False
+
+
+__all__ = ["AsyncRateLimiter"]

--- a/tgbotapp/sender.py
+++ b/tgbotapp/sender.py
@@ -1,0 +1,41 @@
+"""
+/**
+ * @file: tgbotapp/sender.py
+ * @description: Safe message sender that applies the AsyncRateLimiter before Telegram calls.
+ * @dependencies: aiogram, tgbotapp.ratelimiter
+ * @created: 2025-10-02
+ */
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from aiogram import Bot
+from aiogram.types import Message
+
+from .ratelimiter import AsyncRateLimiter
+
+_LIMITER = AsyncRateLimiter()
+
+
+async def safe_send_text(bot: Bot, chat_id: int | str, text: str, **kwargs: Any) -> Message:
+    """Send a text message respecting global and per-chat limits."""
+
+    await _LIMITER.acquire(chat_id)
+    return await bot.send_message(chat_id=chat_id, text=text, **kwargs)
+
+
+def get_rate_limiter() -> AsyncRateLimiter:
+    """Return the process-wide rate limiter instance."""
+
+    return _LIMITER
+
+
+def set_rate_limiter(limiter: AsyncRateLimiter) -> None:
+    """Override the global rate limiter instance (primarily for testing)."""
+
+    global _LIMITER
+    _LIMITER = limiter
+
+
+__all__ = ["safe_send_text", "get_rate_limiter", "set_rate_limiter", "AsyncRateLimiter"]


### PR DESCRIPTION
## Summary
- implement a sliding-window `AsyncRateLimiter` and reusable `safe_send_text` wrapper for bot messaging
- switch Telegram handlers to the safe sender so global, per-chat, and group limits are enforced consistently
- cover the limiter and sender logic with dedicated async unit tests and document the change in the changelog/task tracker

## Testing
- `pytest tests/telegram/test_rate_limiter.py`


------
https://chatgpt.com/codex/tasks/task_e_68de48a7e15c832ea962122dd3285884