### PR TITLE
feat: strengthen SportMonks preflight check

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,13 @@
+## [2025-10-02] - SportMonks fixtures_between preflight
+### Добавлено
+- Проверка `SPORTMONKS_API_TOKEN` и асинхронный вызов `fixtures_between` в `scripts/preflight_sportmonks.py` с маскировкой токена.
+
+### Изменено
+- Скрипт префлайта SportMonks использует клиента `tgbotapp.sportmonks_client.SportMonks` и печатает итоговую сводку `[OK]` с количеством матчей за сегодня.
+
+### Исправлено
+- Сообщения об ошибках префлайта стали лаконичными и не раскрывают токены при отсутствии переменной окружения или сбоях запроса.
+
 ## [2025-09-07] - Async SportMonks client for Telegram bot
 ### Добавлено
 - Асинхронный клиент `tgbotapp/sportmonks_client.py` с валидацией дат, ограничением диапазона в 100 дней и обработкой 429 с уважением `Retry-After`.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: SportMonks fixtures_between preflight (2025-10-02)
+- **Статус**: Завершена
+- **Описание**: Усилить выпускной префлайт SportMonks проверкой токена и асинхронным запросом расписания на сегодня.
+- **Шаги выполнения**:
+  - [x] Добавлена проверка `SPORTMONKS_API_TOKEN` и маскировка токена при выводе скрипта.
+  - [x] Настроен вызов `fixtures_between` через клиента `tgbotapp.sportmonks_client.SportMonks` с параметрами UTC/25.
+  - [x] Обновлены `docs/changelog.md` и `docs/tasktracker.md` для фиксации изменений.
+- **Зависимости**: scripts/preflight_sportmonks.py, tgbotapp/sportmonks_client.py, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: Async SportMonks client for Telegram bot (2025-09-07)
 - **Статус**: Завершена
 - **Описание**: Добавить строгий асинхронный клиент SportMonks v3 для пакета tgbotapp с поддержкой ретраев и валидации диапазона дат.


### PR DESCRIPTION
## Summary
- ensure the SportMonks preflight script requires SPORTMONKS_API_TOKEN and masks it before logging
- call the async SportMonks fixtures_between API via the tgbotapp client to report today's fixture count
- document the updated preflight behaviour in the changelog and task tracker

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de500e8200832e9dcbbeab0c5c2b4f