### PR TITLE
feat: harden run_start_check preflights

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,13 @@
+## [2025-10-02] - run_start_check preflight hardening
+### Добавлено
+- Функция `mask` в `scripts/run_start_check.sh` для безопасного вывода значений секретов.
+
+### Изменено
+- Стартовый скрипт выводит маскированные переменные окружения, проверяет `ROLE` и запускает префлайты Redis/SportMonks.
+
+### Исправлено
+- Запуск `ROLE=bot` без токенов теперь завершается ошибкой, обеспечивая предсказуемый фейл старт-чека.
+
 ## [2025-10-02] - SportMonks fixtures_between preflight
 ### Добавлено
 - Проверка `SPORTMONKS_API_TOKEN` и асинхронный вызов `fixtures_between` в `scripts/preflight_sportmonks.py` с маскировкой токена.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1453,6 +1453,15 @@
   - [x] Стадия numeric использует `pip.conf` и проверяет отсутствие SKIP у @needs_np
 - **Зависимости**: .github/workflows/ci.yml, docs/changelog.md, docs/tasktracker.md
 
+## Задача: Усиление run_start_check
+- **Статус**: Завершена
+- **Описание**: Маскировать чувствительные токены и запускать префлайты Redis/SportMonks в стартовом скрипте.
+- **Шаги выполнения**:
+  - [x] Добавлена функция маскировки и безопасный вывод переменных окружения.
+  - [x] Интегрированы префлайты Redis и SportMonks с корректной обработкой статусов.
+  - [x] Обновлены документационные файлы changelog/tasktracker.
+- **Зависимости**: scripts/run_start_check.sh, scripts/preflight_redis.py, scripts/preflight_sportmonks.py, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: Sentry фичефлаг и метки метрик
 - **Статус**: Завершена
 - **Описание**: Добавить SENTRY_ENABLED, GIT_SHA, метки service/env/version и счётчик jobs_registered_total.

--- a/scripts/run_start_check.sh
+++ b/scripts/run_start_check.sh
@@ -8,6 +8,18 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+mask() {
+    local value="${1-}"
+
+    if [[ -z "${value}" ]]; then
+        printf '<missing>'
+        return
+    fi
+
+    local prefix="${value:0:4}"
+    printf '%s***' "${prefix}"
+}
+
 export METRICS_ENABLED="false"
 export SCHEDULES_ENABLED="false"
 export EXTERNAL_CLIENTS_ENABLED="false"
@@ -15,7 +27,28 @@ export API_ENABLED="false"
 
 ROLE_VALUE="${ROLE:-}"
 
-echo "[run_start_check] ROLE=${ROLE_VALUE}"
+if [[ -z "${ROLE_VALUE}" ]]; then
+    echo "[error] ROLE environment variable must be set" >&2
+    exit 1
+fi
+
+echo "[env] ROLE=${ROLE_VALUE}"
+echo "[env] TELEGRAM_BOT_TOKEN=$(mask "${TELEGRAM_BOT_TOKEN:-}")"
+echo "[env] SPORTMONKS_API_TOKEN=$(mask "${SPORTMONKS_API_TOKEN:-}")"
+
+echo "[preflight] redis"
+if python3 scripts/preflight_redis.py; then
+    echo "[preflight] redis check finished"
+else
+    redis_status=$?
+    echo "[warning] redis preflight exited with status ${redis_status}" >&2
+fi
+
+ROLE_NORMALIZED="${ROLE_VALUE,,}"
+if [[ "${ROLE_NORMALIZED}" == "bot" ]]; then
+    echo "[preflight] sportmonks"
+    python3 scripts/preflight_sportmonks.py
+fi
 
 env ROLE="${ROLE_VALUE}" \
     USE_OFFLINE_STUBS="${USE_OFFLINE_STUBS:-1}" \


### PR DESCRIPTION
## Summary
- ensure `scripts/run_start_check.sh` masks sensitive tokens and requires ROLE to be set
- add redis and conditional sportmonks preflight execution with warning handling for redis failures
- update changelog and task tracker to capture the new run_start_check behavior

## Testing
- ROLE=web TELEGRAM_BOT_TOKEN=abcd1234 SPORTMONKS_API_TOKEN=efgh5678 scripts/run_start_check.sh
- ROLE=bot scripts/run_start_check.sh

------
https://chatgpt.com/codex/tasks/task_e_68de520b1a5c832e9d59e86fbe8d8881