### PR TITLE
feat: add asyncpg database url builder

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,14 @@
+## [2025-10-02] - Database URL builder for asyncpg
+### Добавлено
+- Утилита `tgbotapp/db_url.py` для безопасной сборки `postgresql+asyncpg` DSN из переменных окружения и цитирования пароля.
+- Юнит-тесты `tests/test_db_url.py`, подтверждающие приоритет `DATABASE_URL`, экранирование пароля и обработку неполной конфигурации.
+
+### Изменено
+- —
+
+### Исправлено
+- —
+
 ## [2025-10-02] - run_start_check preflight hardening
 ### Добавлено
 - Функция `mask` в `scripts/run_start_check.sh` для безопасного вывода значений секретов.

--- a/docs/tasktracker.md
+++ b/docs/tasktracker.md
@@ -1,3 +1,12 @@
+## Задача: Database URL builder for asyncpg (2025-10-02)
+- **Статус**: Завершена
+- **Описание**: Добавить безопасный билдер строки подключения PostgreSQL для asyncpg с приоритетом переменной `DATABASE_URL`.
+- **Шаги выполнения**:
+  - [x] Реализована функция `build_db_url` в `tgbotapp/db_url.py` с цитированием пароля и fallback на раздельные переменные.
+  - [x] Добавлены тесты `tests/test_db_url.py` для проверки приоритета `DATABASE_URL`, экранирования пароля и обработки неполной конфигурации.
+  - [x] Обновлены `docs/changelog.md` и `docs/tasktracker.md` для документирования изменений.
+- **Зависимости**: tgbotapp/db_url.py, tests/test_db_url.py, docs/changelog.md, docs/tasktracker.md
+
 ## Задача: SportMonks fixtures_between preflight (2025-10-02)
 - **Статус**: Завершена
 - **Описание**: Усилить выпускной префлайт SportMonks проверкой токена и асинхронным запросом расписания на сегодня.

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -1,0 +1,55 @@
+"""/**
+ * @file: test_db_url.py
+ * @description: Tests for the database URL builder utility.
+ * @dependencies: os, pytest, tgbotapp.db_url
+ * @created: 2025-10-02
+ */
+Tests for :mod:`tgbotapp.db_url`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tgbotapp.db_url import build_db_url
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure database-related environment variables are isolated per test."""
+
+    keys = ["DATABASE_URL", "DB_USER", "DB_PASSWORD", "DB_HOST", "DB_NAME"]
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_returns_database_url_when_defined(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The explicit ``DATABASE_URL`` value takes priority."""
+
+    expected = "postgresql+asyncpg://user:pass@host:5432/db"
+    monkeypatch.setenv("DATABASE_URL", expected)
+    monkeypatch.setenv("DB_PASSWORD", "should_not_be_used")
+
+    assert build_db_url() == expected
+
+
+def test_builds_url_from_individual_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The URL is assembled from individual credentials when needed."""
+
+    monkeypatch.setenv("DB_USER", "bot")
+    monkeypatch.setenv("DB_PASSWORD", "p@ss/word")
+    monkeypatch.setenv("DB_HOST", "db.internal")
+    monkeypatch.setenv("DB_NAME", "telegram")
+
+    url = build_db_url()
+
+    assert url == "postgresql+asyncpg://bot:p%40ss%2Fword@db.internal:5432/telegram"
+
+
+def test_returns_none_when_credentials_are_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing credentials result in ``None`` to indicate unavailable DSN."""
+
+    monkeypatch.setenv("DB_USER", "bot")
+    monkeypatch.setenv("DB_PASSWORD", "secret")
+
+    assert build_db_url() is None

--- a/tgbotapp/db_url.py
+++ b/tgbotapp/db_url.py
@@ -1,0 +1,45 @@
+"""/**
+ * @file: db_url.py
+ * @description: Utility helpers to assemble database connection URL from environment variables.
+ * @dependencies: os, urllib.parse, typing
+ * @created: 2025-10-02
+ */
+Utilities for building database connection URLs.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+from urllib.parse import quote_plus
+
+
+def build_db_url() -> Optional[str]:
+    """Return the database URL from environment variables.
+
+    The priority is an explicitly provided ``DATABASE_URL``. If it is not set,
+    the URL is composed from individual credentials: ``DB_USER``,
+    ``DB_PASSWORD``, ``DB_HOST`` and ``DB_NAME``. The password is quoted using
+    :func:`urllib.parse.quote_plus` to keep special characters safe for DSN
+    usage.
+
+    Returns:
+        Optional[str]: A ready-to-use SQLAlchemy asyncpg DSN when enough
+        information is available. ``None`` when neither ``DATABASE_URL`` nor
+        the individual credentials are fully defined.
+    """
+
+    url = os.environ.get("DATABASE_URL")
+    if url:
+        return url
+
+    user = os.environ.get("DB_USER")
+    password = os.environ.get("DB_PASSWORD")
+    host = os.environ.get("DB_HOST")
+    name = os.environ.get("DB_NAME")
+
+    if not all([user, password, host, name]):
+        return None
+
+    safe_password = quote_plus(password)
+    return f"postgresql+asyncpg://{user}:{safe_password}@{host}:5432/{name}"


### PR DESCRIPTION
## Summary
- add `tgbotapp/db_url.py` with `build_db_url` that prefers `DATABASE_URL` and assembles a quoted asyncpg DSN from individual credentials
- cover the helper with `tests/test_db_url.py` ensuring password quoting, precedence, and missing credential handling
- update the changelog and task tracker to document the new utility

## Testing
- pytest tests/test_db_url.py

------
https://chatgpt.com/codex/tasks/task_e_68de54f37ea4832e9af36211bd0cd0e2